### PR TITLE
Add schema preflight check before ingestion runs

### DIFF
--- a/cms_pricing/cli/ingestion.py
+++ b/cms_pricing/cli/ingestion.py
@@ -10,7 +10,9 @@ from typing import List, Optional
 
 import structlog
 
+from cms_pricing.database import SessionLocal
 from cms_pricing.ingestion.nearest_zip_ingestion import NearestZipIngestionPipeline
+from cms_pricing.ingestion.utils import assert_schema_is_current, SchemaOutOfDateError
 
 logger = structlog.get_logger()
 
@@ -43,7 +45,18 @@ async def run_ingestion(
         )
     
     logger.info("Starting data ingestion", sources=sources, dry_run=dry_run)
-    
+
+    try:
+        session = SessionLocal()
+        try:
+            assert_schema_is_current(session)
+        finally:
+            session.close()
+    except SchemaOutOfDateError as exc:
+        logger.error("Database schema check failed", error=str(exc))
+        print(f"\n❌ Ingestion aborted: {exc}")
+        return 1
+
     try:
         pipeline = NearestZipIngestionPipeline(output_dir)
         

--- a/cms_pricing/ingestion/utils/__init__.py
+++ b/cms_pricing/ingestion/utils/__init__.py
@@ -1,0 +1,8 @@
+"""Utility helpers for ingestion pipeline."""
+
+from .schema import assert_schema_is_current, SchemaOutOfDateError
+
+__all__ = [
+    "assert_schema_is_current",
+    "SchemaOutOfDateError",
+]

--- a/cms_pricing/ingestion/utils/schema.py
+++ b/cms_pricing/ingestion/utils/schema.py
@@ -1,0 +1,135 @@
+"""Schema preflight helpers used by ingestion pipelines."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Optional, Union, Iterator
+
+import structlog
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from sqlalchemy import text
+from sqlalchemy.engine import Connection, Engine
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+logger = structlog.get_logger(__name__)
+
+
+class SchemaOutOfDateError(RuntimeError):
+    """Raised when the database schema revision is behind the expected Alembic head."""
+
+
+@contextmanager
+def _managed_connection(db: Union[Session, Engine, Connection]) -> Iterator[Connection]:
+    """Yield a SQLAlchemy connection, handling lifecycle for various inputs."""
+
+    if isinstance(db, Session):
+        connection = db.connection()
+        close_after_use = False
+    elif isinstance(db, Engine):
+        connection = db.connect()
+        close_after_use = True
+    elif isinstance(db, Connection):
+        connection = db
+        close_after_use = False
+    elif hasattr(db, "connection"):
+        connection = db.connection()
+        close_after_use = False
+    else:
+        raise TypeError(
+            "assert_schema_is_current expects a Session, Engine, or Connection; "
+            f"got {type(db)!r}"
+        )
+
+    try:
+        yield connection
+    finally:
+        if close_after_use:
+            connection.close()
+
+
+def _load_expected_head(alembic_ini_path: Optional[Union[str, Path]]) -> str:
+    """Return the current Alembic head revision from migration scripts."""
+
+    if alembic_ini_path is None:
+        alembic_ini_path = Path(__file__).resolve().parents[3] / "alembic.ini"
+
+    cfg = Config(str(alembic_ini_path))
+    script_directory = ScriptDirectory.from_config(cfg)
+    return script_directory.get_current_head()
+
+
+def _extract_version(result_row) -> Optional[str]:
+    """Coerce Alembic version row into a simple string."""
+
+    if result_row is None:
+        return None
+
+    try:
+        # SQLAlchemy 1.x returns tuple-like rows
+        return result_row[0]
+    except (TypeError, KeyError, IndexError):
+        pass
+
+    try:
+        return result_row["version_num"]
+    except Exception:  # pragma: no cover - very defensive
+        return getattr(result_row, "version_num", None)
+
+
+def assert_schema_is_current(
+    db: Union[Session, Engine, Connection],
+    *,
+    alembic_ini_path: Optional[Union[str, Path]] = None,
+) -> str:
+    """Ensure the connected database matches the latest Alembic head.
+
+    Args:
+        db: SQLAlchemy session, engine, or connection pointing at the target database.
+        alembic_ini_path: Optional path to ``alembic.ini`` if a non-standard location is used.
+
+    Returns:
+        The current database revision if it matches the Alembic head.
+
+    Raises:
+        SchemaOutOfDateError: If the schema revision is missing or does not match the Alembic head.
+    """
+
+    expected_head = _load_expected_head(alembic_ini_path)
+
+    with _managed_connection(db) as connection:
+        try:
+            result = connection.execute(text("SELECT version_num FROM alembic_version"))
+            current_row = result.first()
+        except SQLAlchemyError as exc:
+            logger.error("Failed to read alembic_version", error=str(exc))
+            raise SchemaOutOfDateError(
+                "Unable to determine current database schema revision. "
+                "Run `alembic upgrade head` before retrying ingestion."
+            ) from exc
+
+    current_revision = _extract_version(current_row)
+    if not current_revision:
+        raise SchemaOutOfDateError(
+            "Database does not report an Alembic revision. "
+            "Run `alembic upgrade head` before retrying ingestion."
+        )
+
+    if current_revision != expected_head:
+        raise SchemaOutOfDateError(
+            "Database schema revision '{current}' does not match Alembic head '{head}'. "
+            "Run `alembic upgrade head` before retrying ingestion.".format(
+                current=current_revision,
+                head=expected_head,
+            )
+        )
+
+    logger.debug(
+        "Database schema is current",
+        current_revision=current_revision,
+        expected_head=expected_head,
+    )
+
+    return current_revision

--- a/prds/RUN-rvu-ingestion-v1.0.md
+++ b/prds/RUN-rvu-ingestion-v1.0.md
@@ -136,6 +136,7 @@ Record manifest path, release_id, batch_id, and audit output.
 ## 6. Troubleshooting
 | Symptom | Likely Cause | Resolution |
 |---------|--------------|------------|
+| `SchemaOutOfDateError: Database schema revision ...` | Postgres migrations behind Alembic head | Run `alembic upgrade head`, rerun preflight, and restart ingestion |
 | `ValueError: RVU snapshot not available` | Wrong release ID or snapshots missing | Run latest release without `--release-id` or ingest missing quarter first |
 | `manifest_path` still `.json` after run | File moved or deleted | Run repair script; ensure manifests are retained in backup |
 | Parser errors on download files | CMS changed schema or corrupted download | Inspect raw files under `$RVU_OUTPUT_DIR/raw`; update parser or re-download |

--- a/run_ingestion.py
+++ b/run_ingestion.py
@@ -11,7 +11,9 @@ from pathlib import Path
 project_root = Path(__file__).parent
 sys.path.insert(0, str(project_root))
 
+from cms_pricing.database import SessionLocal
 from cms_pricing.ingestion.nearest_zip_ingestion import NearestZipIngestionPipeline
+from cms_pricing.ingestion.utils import assert_schema_is_current, SchemaOutOfDateError
 
 
 async def main():
@@ -20,6 +22,13 @@ async def main():
     print("=" * 60)
     
     try:
+        # Ensure database schema is on the expected Alembic head
+        session = SessionLocal()
+        try:
+            assert_schema_is_current(session)
+        finally:
+            session.close()
+
         # Create pipeline
         pipeline = NearestZipIngestionPipeline("./data/ingestion")
         
@@ -64,6 +73,9 @@ async def main():
             print(f"\n❌ Ingestion failed")
             return 1
             
+    except SchemaOutOfDateError as exc:
+        print(f"\n❌ Ingestion aborted: {exc}")
+        return 1
     except Exception as e:
         print(f"\n❌ Ingestion failed: {e}")
         import traceback

--- a/tests/ingestion/test_schema_preflight.py
+++ b/tests/ingestion/test_schema_preflight.py
@@ -1,0 +1,56 @@
+"""Tests for the ingestion schema preflight check."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from cms_pricing.ingestion.utils import assert_schema_is_current, SchemaOutOfDateError
+
+
+@pytest.fixture
+def mock_script_directory():
+    with patch("cms_pricing.ingestion.utils.schema.ScriptDirectory.from_config") as factory:
+        script = MagicMock()
+        factory.return_value = script
+        yield script
+
+
+def _session_with_version(version: str):
+    session = MagicMock(spec=Session)
+    connection = MagicMock()
+    result = MagicMock()
+    result.first.return_value = (version,)
+    connection.execute.return_value = result
+    session.connection.return_value = connection
+    return session
+
+
+def test_assert_schema_is_current_passes_when_revision_matches(mock_script_directory):
+    mock_script_directory.get_current_head.return_value = "1234abcd"
+    session = _session_with_version("1234abcd")
+
+    revision = assert_schema_is_current(session)
+
+    assert revision == "1234abcd"
+    session.connection.assert_called_once()
+    session.connection.return_value.execute.assert_called_once()
+
+
+def test_assert_schema_is_current_raises_for_stale_revision(mock_script_directory):
+    mock_script_directory.get_current_head.return_value = "expected"
+    session = _session_with_version("stale")
+
+    with pytest.raises(SchemaOutOfDateError) as excinfo:
+        assert_schema_is_current(session)
+
+    assert "alembic upgrade head" in str(excinfo.value)
+
+
+def test_assert_schema_is_current_handles_missing_version(mock_script_directory):
+    mock_script_directory.get_current_head.return_value = "expected"
+    session = _session_with_version("expected")
+    session.connection.return_value.execute.return_value.first.return_value = None
+
+    with pytest.raises(SchemaOutOfDateError):
+        assert_schema_is_current(session)


### PR DESCRIPTION
## Summary
- add an ingestion schema preflight helper that compares the database revision with the Alembic head
- invoke the schema guard from the CLI and standalone pipeline runner so executions abort before work starts when migrations are missing
- cover matching and stale revisions in unit tests and document the new operator guidance in the RVU ingestion runbook

## Testing
- pytest tests/ingestion/test_schema_preflight.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69126d50277083319f27dd1e24d4e679)