### PR TITLE
Add atomic publish writes and transactional snapshot registration

### DIFF
--- a/cms_pricing/ingestion/ingestors/mpfs_ingestor.py
+++ b/cms_pricing/ingestion/ingestors/mpfs_ingestor.py
@@ -16,13 +16,13 @@ MPFS Ingestor creates curated views that reference RVU data:
 """
 
 import asyncio
-import hashlib
 import io
 import json
 import os
 import re
 import uuid
 import zipfile
+import shutil
 from datetime import datetime, date
 from pathlib import Path
 from typing import Dict, Any, List, Optional, Tuple
@@ -54,6 +54,7 @@ from ..adapters.data_adapters import AdapterFactory, AdapterConfig
 from ..validators.validation_engine import ValidationEngine
 from ..enrichers.data_enrichers import EnricherFactory
 from ..publishers.data_publishers import PublisherFactory
+from ..utils.atomic import atomic_write, atomic_write_json, compute_sha256
 from ..observability.dis_observability import (
     DISObservabilityCollector,
     FreshnessMetrics,
@@ -1216,25 +1217,26 @@ class MPFSIngestor(BaseDISIngestor):
         manifest: Dict[str, Any] = {}
         manifest_path = output_root / "manifest.json"
 
+        manifest_entries: Dict[str, Dict[str, Any]] = {}
+        file_digests: Dict[str, str] = {}
+        effective_ranges: Dict[str, Tuple[Optional[date], Optional[date]]] = {}
+
         for dataset_name, df in curated_views.items():
             file_path = output_root / f"{dataset_name}.parquet"
-            df.to_parquet(file_path, compression="snappy", index=False)
-            digest = self._calculate_dataset_digest(df)
+
+            def _write_parquet(target: Path) -> None:
+                df.to_parquet(target, compression="snappy", index=False)
+
+            atomic_write(file_path, _write_parquet)
+            digest = compute_sha256(file_path)
+            file_digests[dataset_name] = digest
 
             effective_from, effective_to = self._infer_effective_range(df)
             effective_from = self._normalize_snapshot_date(effective_from) or datetime.now().date()
             effective_to = self._normalize_snapshot_date(effective_to)
-            self.snapshot_service.register_snapshot(
-                dataset_id=dataset_name,
-                release_id=release_id,
-                digest=digest,
-                effective_from=effective_from,
-                effective_to=effective_to,
-                manifest_url=str(manifest_path),
-                curated_path=str(file_path),
-            )
+            effective_ranges[dataset_name] = (effective_from, effective_to)
 
-            manifest[dataset_name] = {
+            manifest_entries[dataset_name] = {
                 "path": str(file_path),
                 "rows": len(df),
                 "digest": digest,
@@ -1242,13 +1244,33 @@ class MPFSIngestor(BaseDISIngestor):
                 "effective_to": str(effective_to) if effective_to else None,
             }
 
-        manifest_path.write_text(json.dumps(manifest, indent=2))
+        manifest_payload = manifest_entries.copy()
 
-        observability_report = self._generate_observability_report(stage_frame, manifest)
+        session = self.snapshot_service.db
+        try:
+            atomic_write_json(manifest_path, manifest_payload)
+            with session.begin():
+                for dataset_name, info in manifest_entries.items():
+                    normalized_from, normalized_to = effective_ranges.get(dataset_name, (datetime.now().date(), None))
+                    self.snapshot_service.register_snapshot(
+                        dataset_id=dataset_name,
+                        release_id=release_id,
+                        digest=file_digests[dataset_name],
+                        effective_from=normalized_from,
+                        effective_to=normalized_to,
+                        manifest_url=str(manifest_path),
+                        curated_path=info.get("path"),
+                        autocommit=False,
+                    )
+        except Exception:
+            self._cleanup_release_directory(output_root)
+            raise
+
+        observability_report = self._generate_observability_report(stage_frame, manifest_entries)
 
         summary = {
             name: {"rows": info["rows"], "path": info["path"], "digest": info["digest"]}
-            for name, info in manifest.items()
+            for name, info in manifest_entries.items()
         }
 
         result = {
@@ -1259,16 +1281,20 @@ class MPFSIngestor(BaseDISIngestor):
             "manifest_path": str(manifest_path),
             "observability_report": observability_report,
             "metadata": stage_frame.metadata,
+            "file_digests": file_digests,
         }
 
         logger.info("MPFS publish stage completed", curated_tables=len(summary))
         return result
 
-    def _calculate_dataset_digest(self, df: pd.DataFrame) -> str:
-        """Calculate SHA256 digest for a dataframe using parquet serialization."""
-        buffer = io.BytesIO()
-        df.to_parquet(buffer, compression="snappy", index=False)
-        return hashlib.sha256(buffer.getvalue()).hexdigest()
+    @staticmethod
+    def _cleanup_release_directory(path: Path) -> None:
+        """Remove partially written release artifacts when registration fails."""
+        try:
+            if path.exists():
+                shutil.rmtree(path)
+        except Exception as err:
+            logger.warning("Failed to cleanup release directory", path=str(path), error=str(err))
 
     def _infer_effective_range(self, df: pd.DataFrame) -> Tuple[Optional[date], Optional[date]]:
         """Infer effective date range from dataframe columns."""

--- a/cms_pricing/ingestion/ingestors/rvu_ingestor.py
+++ b/cms_pricing/ingestion/ingestors/rvu_ingestor.py
@@ -13,6 +13,7 @@ This module implements a fully DIS-compliant ingestor for all RVU-related datase
 import asyncio
 import hashlib
 import json
+import shutil
 import re
 import uuid
 from collections import defaultdict
@@ -1128,6 +1129,8 @@ class RVUIngestor(BaseDISIngestor):
         export_artifacts = publish_result.get("export_artifacts") or {}
         manifest_path = export_artifacts.get("manifest")
         manifest_path_str = str(manifest_path) if manifest_path else None
+        dataset_digests = publish_result.get("file_digests") or {}
+        curated_directory = publish_result.get("curated_directory")
 
         dataset_paths = {
             "rvu_items": curated_tables.get("pprrvu"),
@@ -1137,37 +1140,73 @@ class RVUIngestor(BaseDISIngestor):
             "oppscap": curated_tables.get("oppscap"),
         }
 
-        for dataset_id, parquet_path in dataset_paths.items():
-            if not parquet_path:
-                continue
-            path_obj = Path(parquet_path)
-            if not path_obj.exists():
-                logger.warning(
-                    "Curated parquet missing for snapshot registration",
-                    dataset_id=dataset_id,
-                    path=str(path_obj)
-                )
-                continue
+        dataset_sources = {
+            "rvu_items": "pprrvu",
+            "gpci_indices": "gpci",
+            "anescf": "anescf",
+            "localitycounty": "localitycounty",
+            "oppscap": "oppscap",
+        }
 
-            digest = self._calculate_file_digest(path_obj)
-            normalized_path = self._normalize_snapshot_path(path_obj)
-            # Derive dataset-specific release ID (e.g., gpci_YYYY_S)
-            specific_release_id = self._dataset_release_id(dataset_id, release_id)
+        session = snapshot_service.db
+        registered_pairs = []
 
-            snapshot_service.register_snapshot(
-                dataset_id=dataset_id,
-                release_id=specific_release_id,
-                digest=digest,
-                effective_from=effective_from,
-                manifest_url=manifest_path_str or normalized_path,
-                curated_path=normalized_path,
+        try:
+            with session.begin():
+                for dataset_id, parquet_path in dataset_paths.items():
+                    if not parquet_path:
+                        continue
+                    path_obj = Path(parquet_path)
+                    if not path_obj.exists():
+                        logger.warning(
+                            "Curated parquet missing for snapshot registration",
+                            dataset_id=dataset_id,
+                            path=str(path_obj)
+                        )
+                        continue
+
+                    source_key = dataset_sources.get(dataset_id)
+                    digest = dataset_digests.get(source_key) if source_key else None
+                    if not digest:
+                        digest = self._calculate_file_digest(path_obj)
+                    normalized_path = self._normalize_snapshot_path(path_obj)
+                    specific_release_id = self._dataset_release_id(dataset_id, release_id)
+
+                    snapshot_service.register_snapshot(
+                        dataset_id=dataset_id,
+                        release_id=specific_release_id,
+                        digest=digest,
+                        effective_from=effective_from,
+                        manifest_url=manifest_path_str or normalized_path,
+                        curated_path=normalized_path,
+                        autocommit=False,
+                    )
+                    registered_pairs.append((dataset_id, specific_release_id))
+                    logger.info(
+                        "Registered dataset snapshot",
+                        dataset_id=dataset_id,
+                        release_id=specific_release_id,
+                        effective_from=effective_from
+                    )
+        except Exception as exc:
+            logger.error(
+                "Snapshot registration transaction failed",
+                error=str(exc),
+                release_id=release_id,
+                registered_pairs=registered_pairs,
             )
-            logger.info(
-                "Registered dataset snapshot",
-                dataset_id=dataset_id,
-                release_id=specific_release_id,
-                effective_from=effective_from
-            )
+            if curated_directory:
+                self._cleanup_release_directory(Path(curated_directory))
+            raise
+
+    @staticmethod
+    def _cleanup_release_directory(path: Path) -> None:
+        """Remove partially written release artifacts when registration fails."""
+        try:
+            if path.exists():
+                shutil.rmtree(path)
+        except Exception as err:
+            logger.warning("Failed to cleanup release directory", path=str(path), error=str(err))
 
     @staticmethod
     def _dataset_release_id(dataset_id: str, base_release_id: str) -> str:

--- a/cms_pricing/ingestion/stages/publish.py
+++ b/cms_pricing/ingestion/stages/publish.py
@@ -1,5 +1,4 @@
-"""
-Publish stage module for DIS pipeline.
+"""Publish stage module for DIS pipeline.
 
 Per DIS §3.6: Create snapshot tables, latest-effective views, load to database.
 This module extracts publishing logic from ingestors for reuse across datasets.
@@ -9,12 +8,13 @@ import json
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 import structlog
 
 import pandas as pd
 
 from ..contracts.ingestor_spec import StageFrame
+from ..utils.atomic import atomic_write, atomic_write_json, compute_sha256
 
 logger = structlog.get_logger()
 
@@ -170,13 +170,13 @@ async def execute_publish(
         }
         
         docs_path = docs_dir / "dataset_documentation.json"
-        with open(docs_path, 'w') as f:
-            json.dump(data_docs, f, indent=2)
-        
+        atomic_write_json(docs_path, data_docs)
+
         # Save data with idempotent upserts per DIS §3.6
         saved_paths: Dict[str, Path] = {}
+        file_digests: Dict[str, str] = {}
         if enriched_data:
-            saved_paths = _save_data_with_upserts(enriched_data, data_dir, vintage_date)
+            saved_paths, file_digests = _save_data_with_upserts(enriched_data, data_dir, vintage_date)
         
         # Load data into database if enabled
         load_results = {}
@@ -218,13 +218,13 @@ async def execute_publish(
                     "name": name,
                     "records": dataset_counts.get(name, 0),
                     "parquet_path": str(saved_paths.get(name)) if saved_paths.get(name) else None,
+                    "digest": file_digests.get(name),
                 }
                 for name in sorted(enriched_data.keys()) if isinstance(enriched_data, dict)
             ]
         }
         manifest_path = curated_dir / "manifest.json"
-        with open(manifest_path, 'w') as f:
-            json.dump(manifest_payload, f, indent=2)
+        atomic_write_json(manifest_path, manifest_payload)
         
         logger.info("Publish stage completed", 
                    batch_id=batch_id,
@@ -242,6 +242,7 @@ async def execute_publish(
             "latest_effective_view": str(view_path) if view_path else None,
             "record_count": total_records,
             "curated_tables": saved_paths,
+            "file_digests": file_digests,
             "latest_effective_views": [str(view_path)] if view_path else [],
             "export_artifacts": {
                 "schema_contract": str(docs_dir / "schema_contract.json"),
@@ -261,22 +262,39 @@ async def execute_publish(
         }
 
 
-def _save_data_with_upserts(enriched_data: Dict[str, Any], data_dir: Path, vintage_date: str) -> Dict[str, Path]:
+def _save_data_with_upserts(
+    enriched_data: Dict[str, Any], data_dir: Path, vintage_date: str
+) -> Tuple[Dict[str, Path], Dict[str, str]]:
     """Save enriched data with idempotent upserts per DIS §3.6."""
-    saved_paths = {}
+    saved_paths: Dict[str, Path] = {}
+    digests: Dict[str, str] = {}
     try:
         import pandas as pd
+
         for dataset_name, df in enriched_data.items():
-            if isinstance(df, pd.DataFrame) and not df.empty:
-                parquet_path = data_dir / f"{dataset_name}_{vintage_date}.parquet"
-                df.to_parquet(parquet_path, index=False, compression='snappy')
-                saved_paths[dataset_name] = parquet_path
-                logger.info(f"Saved {dataset_name} to {parquet_path}", records=len(df))
+            if not isinstance(df, pd.DataFrame) or df.empty:
+                continue
+
+            parquet_path = data_dir / f"{dataset_name}_{vintage_date}.parquet"
+
+            def _write(target: Path) -> None:
+                df.to_parquet(target, index=False, compression="snappy")
+
+            atomic_write(parquet_path, _write)
+            saved_paths[dataset_name] = parquet_path
+            digests[dataset_name] = compute_sha256(parquet_path)
+            logger.info(
+                "Saved dataset to parquet",
+                dataset=dataset_name,
+                path=str(parquet_path),
+                records=len(df),
+            )
     except ImportError:
         logger.warning("pandas not available, skipping parquet save")
     except Exception as e:
         logger.error("Failed to save data", error=str(e))
-    return saved_paths
+        raise
+    return saved_paths, digests
 
 
 def _generate_latest_effective_view_sql(dataset_name: str) -> str:

--- a/cms_pricing/ingestion/utils/atomic.py
+++ b/cms_pricing/ingestion/utils/atomic.py
@@ -1,0 +1,79 @@
+"""Utility helpers for atomic filesystem writes used by publish workflows."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Callable, Any
+
+CHUNK_SIZE = 1024 * 1024  # 1MB chunks for fsync + hashing
+
+
+def _fsync_path(path: Path) -> None:
+    """Flush file contents to disk if the path exists."""
+    if not path.exists():
+        return
+    with path.open("rb") as handle:
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def _fsync_directory(path: Path) -> None:
+    """Flush directory metadata to disk if the path exists."""
+    if not path.exists():
+        return
+    fd = os.open(str(path), os.O_DIRECTORY)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _temporary_path(target: Path) -> Path:
+    """Create a temporary path in the target directory."""
+    tmp_dir = target.parent / ".tmp"
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    fd, name = tempfile.mkstemp(dir=tmp_dir, suffix=target.suffix or ".tmp")
+    os.close(fd)
+    return Path(name)
+
+
+def atomic_write(target: Path, writer: Callable[[Path], Any]) -> None:
+    """Write a file via a temporary path and atomically replace the target."""
+    temp_path = _temporary_path(target)
+    try:
+        writer(temp_path)
+        _fsync_path(temp_path)
+        os.replace(temp_path, target)
+        _fsync_directory(target.parent)
+    except Exception:
+        if temp_path.exists():
+            temp_path.unlink(missing_ok=True)  # type: ignore[arg-type]
+        raise
+
+
+def atomic_write_json(target: Path, payload: Any, *, indent: int = 2) -> None:
+    """Atomically persist JSON payloads to disk."""
+    def _write(path: Path) -> None:
+        with path.open("w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=indent)
+            handle.flush()
+            os.fsync(handle.fileno())
+
+    atomic_write(target, _write)
+
+
+def compute_sha256(path: Path) -> str:
+    """Compute SHA256 digest for a file on disk."""
+    import hashlib
+
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(CHUNK_SIZE)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()

--- a/cms_pricing/services/dataset_snapshot_service.py
+++ b/cms_pricing/services/dataset_snapshot_service.py
@@ -57,6 +57,19 @@ class SnapshotMetadata:
     path: Optional[str] = None
 
 
+class SnapshotRegistrationError(Exception):
+    """Raised when snapshot registration fails."""
+
+
+class SnapshotAlreadyExistsError(SnapshotRegistrationError):
+    """Raised when attempting to register a duplicate snapshot without override."""
+
+    def __init__(self, dataset_id: str, release_id: str):
+        super().__init__(f"Snapshot already exists for {dataset_id}:{release_id}")
+        self.dataset_id = dataset_id
+        self.release_id = release_id
+
+
 class DatasetSnapshotService:
     """Service for selecting dataset snapshots by valuation date"""
 
@@ -200,7 +213,10 @@ class DatasetSnapshotService:
         effective_from: date,
         effective_to: Optional[date] = None,
         manifest_url: Optional[str] = None,
-        curated_path: Optional[str] = None
+        curated_path: Optional[str] = None,
+        *,
+        allow_overwrite: bool = False,
+        autocommit: bool = True,
     ) -> DatasetSnapshot:
         """
         Register a new dataset snapshot.
@@ -224,18 +240,19 @@ class DatasetSnapshotService:
         # Check if already exists (efficient PK lookup)
         existing = self.db.get(DatasetSnapshot, (dataset_id, release_id))
         if existing:
-            logger.warning(
-                "Snapshot already exists, updating",
-                dataset_id=dataset_id,
-                release_id=release_id
-            )
+            if not allow_overwrite:
+                raise SnapshotAlreadyExistsError(dataset_id, release_id)
             existing.digest = digest
             existing.effective_from = effective_from
             existing.effective_to = effective_to
             existing.manifest_url = stored_manifest
-            self.db.commit()
+            if autocommit:
+                self.db.commit()
+                self.db.refresh(existing)
+            else:
+                self.db.flush()
             return existing
-        
+
         snapshot = DatasetSnapshot(
             dataset_id=dataset_id,
             release_id=release_id,
@@ -244,10 +261,13 @@ class DatasetSnapshotService:
             effective_to=effective_to,
             manifest_url=stored_manifest
         )
-        
+
         self.db.add(snapshot)
-        self.db.commit()
-        self.db.refresh(snapshot)
+        if autocommit:
+            self.db.commit()
+            self.db.refresh(snapshot)
+        else:
+            self.db.flush()
         
         logger.info(
             "Registered dataset snapshot",

--- a/tests/ingestors/test_mpfs_ingestor_e2e.py
+++ b/tests/ingestors/test_mpfs_ingestor_e2e.py
@@ -50,6 +50,7 @@ class StubSnapshotService:
         effective_to: Optional[date] = None,
         manifest_url: Optional[str] = None,
         curated_path: Optional[str] = None,
+        **kwargs: Any,
     ):
         self.registered.append(
             {

--- a/tests/ingestors/test_rvu_ingestor_e2e.py
+++ b/tests/ingestors/test_rvu_ingestor_e2e.py
@@ -33,6 +33,7 @@ from cms_pricing.ingestion.scrapers.cli import ScraperCLI
 from cms_pricing.models.rvu import Release, RVUItem, GPCIIndex, OPPSCap, AnesCF, LocalityCounty
 from cms_pricing.ingestion.contracts.ingestor_spec import SourceFile
 from cms_pricing.services.dataset_snapshot_service import DatasetSnapshotService
+from cms_pricing.models.dataset_snapshots import DatasetSnapshot
 
 # Test data
 from tests.fixtures.rvu.test_dataset_creator import RVUTestDatasetCreator
@@ -544,13 +545,13 @@ class TestRVUIngestorE2E:
     async def test_observability_metrics(self, rvu_ingestor, sample_source_files, test_db_session):
         """Test 5-pillar observability metrics collection"""
         print("\n📊 Testing observability metrics...")
-        
+
         release_id = f"test_rvu_{uuid.uuid4().hex[:8]}"
         batch_id = str(uuid.uuid4())
-        
+
         # Run pipeline
         pipeline_result = await rvu_ingestor.ingest(release_id, batch_id)
-        
+
         # Verify observability data
         observability = pipeline_result.get("observability", {})
         
@@ -572,7 +573,37 @@ class TestRVUIngestorE2E:
         print(f"   Overall score: {observability['overall_score']}")
         print(f"   Critical alerts: {len(observability['critical_alerts'])}")
         print(f"   Warnings: {len(observability['warnings'])}")
-    
+
+    @pytest.mark.asyncio
+    async def test_snapshot_registration_failure_rolls_back(
+        self,
+        rvu_ingestor,
+        sample_source_files,
+        test_db_session,
+    ):
+        """Ensure snapshot failures do not leave partial DB rows."""
+
+        release_id = f"test_rvu_{uuid.uuid4().hex[:8]}"
+        batch_id = str(uuid.uuid4())
+
+        # Use shared test session so we can verify DB state
+        rvu_ingestor.snapshot_service = DatasetSnapshotService(test_db_session)
+        rvu_ingestor._snapshot_service_managed_session = False
+
+        initial_count = test_db_session.query(DatasetSnapshot).count()
+
+        with patch.object(
+            DatasetSnapshotService,
+            "register_snapshot",
+            side_effect=RuntimeError("forced failure"),
+        ):
+            result = await rvu_ingestor.ingest(release_id, batch_id)
+
+        assert result["status"] == "success"
+
+        final_count = test_db_session.query(DatasetSnapshot).count()
+        assert final_count == initial_count
+
     @pytest.mark.asyncio
     async def test_quarantine_functionality(self, rvu_ingestor, test_data_dir):
         """Test quarantine functionality with invalid data"""

--- a/tests/services/test_dataset_snapshot_service.py
+++ b/tests/services/test_dataset_snapshot_service.py
@@ -12,7 +12,10 @@ from sqlalchemy import text
 from sqlalchemy.exc import OperationalError, ProgrammingError
 
 from cms_pricing.models.dataset_snapshots import DatasetSnapshot
-from cms_pricing.services.dataset_snapshot_service import DatasetSnapshotService
+from cms_pricing.services.dataset_snapshot_service import (
+    DatasetSnapshotService,
+    SnapshotAlreadyExistsError,
+)
 
 
 def check_table_exists(db_session):
@@ -191,8 +194,8 @@ def test_register_snapshot_new(test_db_session):
     assert found is not None
 
 
-def test_register_snapshot_update_existing(test_db_session):
-    """Test that registering existing snapshot updates it"""
+def test_register_snapshot_update_existing_with_override(test_db_session):
+    """Test that registering existing snapshot requires override"""
     if not check_table_exists(test_db_session):
         pytest.skip("dataset_snapshots table not yet created. Run: alembic upgrade head")
     
@@ -207,12 +210,21 @@ def test_register_snapshot_update_existing(test_db_session):
     )
     
     # Register again with different digest
+    with pytest.raises(SnapshotAlreadyExistsError):
+        service.register_snapshot(
+            dataset_id="DMEPOS",
+            release_id="dmepos_2025_annual",
+            digest="sha256:new",
+            effective_from=date(2025, 1, 1),
+        )
+
     snapshot2 = service.register_snapshot(
         dataset_id="DMEPOS",
         release_id="dmepos_2025_annual",
         digest="sha256:new",
         effective_from=date(2025, 1, 1),
-        manifest_url="https://example.com/updated.json"
+        manifest_url="https://example.com/updated.json",
+        allow_overwrite=True,
     )
     
     # Should be the same object (updated)


### PR DESCRIPTION
## Summary
- write publish parquet and manifest artifacts via atomic temporary files and record on-disk digests
- make RVU and MPFS snapshot registration transactional with rollback cleanup and enforce immutability in the snapshot service
- extend test coverage for snapshot overwrite guard and manifest registration failure handling

## Testing
- pytest tests/services/test_dataset_snapshot_service.py *(fails: requires Postgres service)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69127d1d60f48331820371cc59c992bb)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce atomic file writes and SHA256 digests in publish stages, make snapshot registration transactional with rollback and overwrite guard, and update tests accordingly.
> 
> - **Utils**:
>   - Add `ingestion/utils/atomic.py` with `atomic_write`, `atomic_write_json`, and `compute_sha256` for atomic filesystem writes and hashing.
> - **Publish stages**:
>   - `mpfs_ingestor.publish_stage` and shared `stages/publish.execute_publish` now write parquet/manifest atomically, compute file SHA256, and include `file_digests` in results/manifests.
>   - Wrap snapshot registrations in DB transactions (`session.begin`, `autocommit=False`) and clean up partially written release dirs on failure.
> - **RVU ingestor**:
>   - Register snapshots transactionally; use digests from publish results when available; normalize paths; add `_cleanup_release_directory` on failure.
> - **Snapshot service**:
>   - Enforce immutability by default with `SnapshotAlreadyExistsError`; add `allow_overwrite` and `autocommit` flags; adjust commit/flush semantics.
> - **Tests**:
>   - Add/modify tests to cover overwrite guard, transactional rollback on registration failure, and manifest/digest outputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a61f546dbaf8926f239b8918f99997bc07dfa7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->