### PR TITLE
Add live CMS RVU ingest validation

### DIFF
--- a/cms_pricing/ingestion/contracts/cms_gpci_v1.3.json
+++ b/cms_pricing/ingestion/contracts/cms_gpci_v1.3.json
@@ -47,8 +47,8 @@
       "multipleOf": 0.001,
       "nullable": false,
       "description": "Work GPCI index (raw from CMS; floors applied at pricing time)",
-      "min_value": 0.3,
-      "max_value": 2.5,
+      "min_value": 0.2,
+      "max_value": 2.75,
       "sample_values": [1.000, 1.500, 1.122]
     },
     "gpci_pe": {
@@ -60,8 +60,8 @@
       "multipleOf": 0.001,
       "nullable": false,
       "description": "Practice expense GPCI index",
-      "min_value": 0.3,
-      "max_value": 2.5,
+      "min_value": 0.2,
+      "max_value": 2.75,
       "sample_values": [0.869, 1.081, 1.569]
     },
     "gpci_mp": {
@@ -73,8 +73,8 @@
       "multipleOf": 0.001,
       "nullable": false,
       "description": "Malpractice (MP) GPCI index (CMS terminology)",
-      "min_value": 0.3,
-      "max_value": 2.5,
+      "min_value": 0.2,
+      "max_value": 2.75,
       "sample_values": [0.575, 0.592, 1.859]
     },
     "effective_from": {
@@ -136,7 +136,7 @@
   "business_rules": [
     "MAC must be 5 digits (zero-padded)",
     "Locality code must be 2 digits (zero-padded)",
-    "GPCI indices must be between 0.3 and 2.5 (hard schema bounds); values above 2.0 are warning-range but CMS-observed",
+    "GPCI indices should normally be between 0.3 and 2.0; values outside that band are warnings, while values outside 0.2 and 2.75 fail hard validation",
     "Parser delivers raw GPCI values; floors (e.g., Alaska 1.50 work floor) applied at pricing time",
     "Expected 100-120 localities per release (CMS post-CA consolidation universe)",
     "Locality reconfiguration events may cause row count deltas across releases"
@@ -150,7 +150,7 @@
     "gpci_warn_min": 0.30,
     "gpci_warn_max": 2.00,
     "gpci_fail_min": 0.20,
-    "gpci_fail_max": 2.50
+    "gpci_fail_max": 2.75
   },
   "storage_note": "Stored as float64 in Parquet for efficiency. Canonicalized to Decimal with schema-defined precision before hashing to ensure determinism. Enrichment columns (locality_name, state) excluded from hash for stability.",
   "enrichment_note": "locality_name, state are optional enrichments from CMS Locality Key or source files. Parser may include if present in source; warehouse layer performs full enrichment via Locality crosswalk.",
@@ -176,6 +176,7 @@
         "Updated hash_metadata_exclusions to exclude enrichment columns",
         "Added quality_thresholds for CMS-realistic row counts (100-120, fail <90)",
         "Added quality_thresholds for GPCI bounds (warn [0.30, 2.00], fail [0.20, 2.50])",
+        "Updated hard validation bounds to [0.20, 2.75] after live CMS 2026 C data included observed MP GPCI values outside the older 0.30-2.50 schema band",
         "Updated business_rules to reflect CMS locality universe (~109 post-consolidation)",
         "Added enrichment_note explaining parser vs warehouse enrichment strategy",
         "Updated gpci_work description to clarify floors applied at pricing time"

--- a/cms_pricing/ingestion/parsers/anes_parser.py
+++ b/cms_pricing/ingestion/parsers/anes_parser.py
@@ -325,6 +325,13 @@ def _scale_cf_to_usd(df: pd.DataFrame) -> pd.DataFrame:
     Returns:
         DataFrame with anesthesia_cf_usd column (USD decimal)
     """
+    if 'anesthesia_cf_raw' not in df.columns and 'anesthesia_cf_qp_raw' in df.columns:
+        logger.warning(
+            "Only qualifying APM anesthesia CF was present; using it as fallback",
+            note="Current canonical schema stores one anesthesia CF value",
+        )
+        df['anesthesia_cf_raw'] = df['anesthesia_cf_qp_raw']
+
     if 'anesthesia_cf_raw' not in df.columns:
         raise ParseError(
             "Missing anesthesia_cf_raw column for scaling. "
@@ -763,13 +770,32 @@ def _normalize_column_names(df: pd.DataFrame, alias_map: Dict[str, str]) -> pd.D
     """
     norm = {}
     for c in df.columns:
-        cc = str(c).lower().strip().replace('\ufeff', '').replace('\xa0', ' ')
-        cc = ' '.join(cc.split())  # Collapse whitespace
-        norm[c] = alias_map.get(cc, cc).strip().replace(' ', '_')
+        norm[c] = _canonical_column_name(c, alias_map)
     
     df = df.rename(columns=norm)
     
     return df
+
+
+def _canonical_column_name(column_name: Any, alias_map: Dict[str, str]) -> str:
+    """Normalize ANES columns, including 2026 dual-APM CF headers."""
+    cc = str(column_name).lower().strip().replace('\ufeff', '').replace('\xa0', ' ')
+    cc = ' '.join(cc.split())
+
+    alias = alias_map.get(cc)
+    if alias:
+        return alias
+
+    normalized_hyphen = cc.replace('-', ' ')
+    normalized_hyphen = ' '.join(normalized_hyphen.split())
+    if 'national anes cf' in normalized_hyphen:
+        if normalized_hyphen.startswith('non qualifying apm'):
+            return 'anesthesia_cf_raw'
+        if normalized_hyphen.startswith('qualifying apm'):
+            return 'anesthesia_cf_qp_raw'
+        return 'anesthesia_cf_raw'
+
+    return cc.replace(' ', '_')
 
 
 def _load_schema(schema_id: str) -> dict:

--- a/cms_pricing/ingestion/parsers/gpci_parser.py
+++ b/cms_pricing/ingestion/parsers/gpci_parser.py
@@ -19,6 +19,7 @@ Expected Rows: 100-120 (~109 Medicare localities)
 import hashlib
 import time
 import re
+import csv
 from typing import IO, Dict, Any, Tuple, Optional
 from io import BytesIO, StringIO
 from datetime import datetime
@@ -219,6 +220,14 @@ def parse_gpci(
     # Initialize rejects
     rejects_df = pd.DataFrame()
 
+    required_cols = ['mac', 'locality_code', 'gpci_work', 'gpci_pe', 'gpci_mp']
+    missing_cols = [col for col in required_cols if col not in df.columns]
+    if missing_cols:
+        raise ParseError(
+            f"Missing required GPCI columns: {missing_cols}. "
+            f"Available columns: {df.columns.tolist()}"
+        )
+
     # Step 4: Cast dtypes
     df = _cast_dtypes(df, metadata)
     
@@ -410,7 +419,7 @@ def _parse_fixed_width(content: bytes, encoding: str, layout: Dict) -> pd.DataFr
 
 def _parse_csv(content: bytes, encoding: str) -> pd.DataFrame:
     """
-    Parse CSV with dialect sniffing.
+    Parse CSV/TXT with dialect sniffing.
     
     Skips first 2 rows (CMS standard header format):
     - Row 1: Document title
@@ -420,7 +429,19 @@ def _parse_csv(content: bytes, encoding: str) -> pd.DataFrame:
     Raises ParseError on duplicate headers.
     """
     decoded = content.decode(encoding, errors='replace')
-    df = pd.read_csv(StringIO(decoded), skiprows=2, dtype=str)
+    if not decoded.strip():
+        raise ParseError("Empty GPCI file")
+
+    try:
+        df = pd.read_csv(
+            StringIO(decoded),
+            skiprows=2,
+            dtype=str,
+            sep=None,
+            engine='python',
+        )
+    except (pd.errors.ParserError, pd.errors.EmptyDataError, csv.Error) as exc:
+        raise ParseError(f"Failed to parse delimited GPCI file: {exc}") from exc
     
     # Duplicate header guard (pandas mangles to .1, .2, etc.)
     dupes = [c for c in df.columns if '.' in str(c) and '.1' in str(c)]
@@ -456,15 +477,35 @@ def _normalize_column_names(df: pd.DataFrame, alias_map: Dict[str, str]) -> pd.D
     """
     norm = {}
     for c in df.columns:
-        # Strip BOM, NBSP, whitespace
-        cc = str(c).replace('\ufeff', '').replace('\xa0', ' ').strip().lower()
-        # Collapse multiple spaces
-        cc = ' '.join(cc.split())
-        # Apply alias map, convert spaces to underscores
-        norm[c] = alias_map.get(cc, cc).strip().replace(' ', '_')
+        norm[c] = _canonical_column_name(c, alias_map)
     
     df = df.rename(columns=norm)
     return df
+
+
+def _canonical_column_name(column_name: Any, alias_map: Dict[str, str]) -> str:
+    """Normalize CMS GPCI columns, including year-prefixed release headers."""
+    cc = str(column_name).replace('\ufeff', '').replace('\xa0', ' ').strip().lower()
+    cc = ' '.join(cc.split())
+
+    alias = alias_map.get(cc)
+    if alias:
+        return alias
+
+    no_footnote = re.sub(r'\*+$', '', cc).strip()
+    alias = alias_map.get(no_footnote)
+    if alias:
+        return alias
+
+    yearless = re.sub(r'^\d{4}\s+', '', no_footnote).strip()
+    if re.fullmatch(r'pw gpci(?: \(with 1\.0 floor\))?', yearless):
+        return 'gpci_work'
+    if yearless == 'pe gpci':
+        return 'gpci_pe'
+    if yearless == 'mp gpci':
+        return 'gpci_mp'
+
+    return no_footnote.replace(' ', '_')
 
 
 def _cast_dtypes(df: pd.DataFrame, metadata: Dict) -> pd.DataFrame:
@@ -481,9 +522,7 @@ def _cast_dtypes(df: pd.DataFrame, metadata: Dict) -> pd.DataFrame:
     # Dates
     if 'effective_from' not in df.columns:
         # Derive from quarter: A=Jan1, B=Apr1, C=Jul1, D=Oct1
-        quarter = metadata.get('quarter_vintage', 'A')[-1]  # Extract letter
-        month_map = {'A': '01', 'B': '04', 'C': '07', 'D': '10'}
-        month = month_map.get(quarter, '01')
+        month = _effective_month_from_quarter(metadata.get('quarter_vintage', 'A'))
         df['effective_from'] = pd.to_datetime(f"{metadata['product_year']}-{month}-01")
     else:
         df['effective_from'] = pd.to_datetime(df['effective_from'], errors='coerce')
@@ -504,15 +543,29 @@ def _cast_dtypes(df: pd.DataFrame, metadata: Dict) -> pd.DataFrame:
     return df
 
 
+def _effective_month_from_quarter(quarter_vintage: Any) -> str:
+    """Map CMS A/B/C/D and Q1/Q2/Q3/Q4 vintages to effective-start months."""
+    value = str(quarter_vintage or 'A').upper().replace('_', '')
+    if value in {'A', 'B', 'C', 'D'}:
+        quarter = value
+    elif 'Q' in value:
+        quarter = {'1': 'A', '2': 'B', '3': 'C', '4': 'D'}.get(value.split('Q')[-1][:1], 'A')
+    else:
+        quarter = value[-1:]
+
+    month_map = {'A': '01', 'B': '04', 'C': '07', 'D': '10'}
+    return month_map.get(quarter, '01')
+
+
 def _validate_gpci_ranges(df: pd.DataFrame) -> pd.DataFrame:
     """
     Return rows that violate hard range thresholds.
     
     Soft bounds [0.30, 2.00]: warn (logged, not rejected)
-    Hard bounds [0.20, 2.50]: fail (rejected)
+    Hard bounds [0.20, 2.75]: fail (rejected)
     """
     warn_low, warn_high = 0.30, 2.00
-    hard_low, hard_high = 0.20, 2.50
+    hard_low, hard_high = 0.20, 2.75
     
     # Convert to numeric for comparison (canonicalize_numeric_col returns strings)
     gpci_work_num = pd.to_numeric(df['gpci_work'], errors='coerce')
@@ -548,9 +601,9 @@ def _validate_gpci_ranges(df: pd.DataFrame) -> pd.DataFrame:
         # More specific error message for negatives
         has_negatives = negative_mask[mask].any()
         if has_negatives:
-            rejects['validation_error'] = 'GPCI value is negative or out of hard bounds [0.20, 2.50]'
+            rejects['validation_error'] = 'GPCI value is negative or out of hard bounds [0.20, 2.75]'
         else:
-            rejects['validation_error'] = 'GPCI value out of hard bounds [0.20, 2.50]'
+            rejects['validation_error'] = 'GPCI value out of hard bounds [0.20, 2.75]'
         rejects['validation_severity'] = 'BLOCK'
         rejects['validation_rule'] = 'gpci_hard_range'
         

--- a/cms_pricing/ingestion/parsers/layout_registry.py
+++ b/cms_pricing/ingestion/parsers/layout_registry.py
@@ -126,6 +126,16 @@ ANES_2025D_LAYOUT = {
     }
 }
 
+ANES_2026_LAYOUT = {
+    **ANES_2025D_LAYOUT,
+    'version': 'v2026.3.0',
+    'source_version': '2026',
+    'notes': [
+        '2026 TXT carries qualifying and non-qualifying APM CF columns',
+        'The canonical single-CF schema uses the non-qualifying APM CF at positions 73-77',
+    ],
+}
+
 # ===================================================================
 # LOCALITY-COUNTY LAYOUTS
 # ===================================================================
@@ -183,6 +193,11 @@ LAYOUT_REGISTRY = {
     # ANES layouts (D = October/Q4)
     ('anes', '2025', 'D'): ANES_2025D_LAYOUT,
     ('anes', '2025', None): ANES_2025D_LAYOUT,  # Annual
+    ('anes', '2026', 'A'): ANES_2026_LAYOUT,
+    ('anes', '2026', 'B'): ANES_2026_LAYOUT,
+    ('anes', '2026', 'C'): ANES_2026_LAYOUT,
+    ('anes', '2026', 'D'): ANES_2026_LAYOUT,
+    ('anes', '2026', None): ANES_2026_LAYOUT,
     
     # Locality layouts (D = October/Q4)
     ('locco', '2025', 'D'): LOCCO_2025D_LAYOUT,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,7 @@ services:
       - ./scripts:/app/scripts
       - ./tests:/app/tests
       - ./sample_data:/app/sample_data:ro
+      - ./pytest.ini:/app/pytest.ini
       - ./alembic.ini:/app/alembic.ini
       - ./data:/app/data
       - ./logs:/app/logs
@@ -78,6 +79,7 @@ services:
       - ./scripts:/app/scripts
       - ./tests:/app/tests
       - ./sample_data:/app/sample_data:ro
+      - ./pytest.ini:/app/pytest.ini
       - ./alembic.ini:/app/alembic.ini
       - ./data:/app/data
       - ./logs:/app/logs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ markers = [
     "edge_case: marks tests as edge case/real-world quirk tests",
     "negative: marks tests as negative/error case tests",
     "real_source: marks tests for authentic CMS source file parity (QTS §5.1.3)",
+    "live_cms: marks tests that download current CMS source files and should run only when explicitly enabled",
     "ingestor: marks tests as ingestor/parser tests",
     "gpci: marks tests related to GPCI parser",
     "prd_docs: marks tests related to PRD documentation",

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,5 +6,18 @@ filterwarnings =
     ignore:is_categorical_dtype is deprecated:DeprecationWarning
 
 markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')
+    integration: marks tests as integration tests
+    golden: marks tests as golden/parity tests
+    edge_case: marks tests as edge case/real-world quirk tests
+    negative: marks tests as negative/error case tests
+    real_source: marks tests for authentic CMS source file parity (QTS §5.1.3)
+    live_cms: mark tests that download current CMS source files and should run only when explicitly enabled
     ingestor: mark tests related to ingestor workflows
-
+    gpci: marks tests related to GPCI parser
+    prd_docs: marks tests related to PRD documentation
+    scraper: marks tests related to scrapers
+    geography: marks tests related to geography/nearest_zip
+    api: marks tests related to API routers
+    e2e: marks tests as end-to-end tests
+    performance: marks tests as performance/benchmark tests

--- a/scripts/validate_live_cms_ingest.py
+++ b/scripts/validate_live_cms_ingest.py
@@ -1,0 +1,474 @@
+#!/usr/bin/env python3
+"""Opt-in live CMS ingestion validation.
+
+This harness intentionally avoids production database writes. It discovers the
+latest live CMS RVU release, downloads the selected source artifact(s), runs the
+RVU DIS stages through publish, and writes a compact JSON validation report.
+
+Usage:
+    ENABLE_LIVE_CMS=1 python scripts/validate_live_cms_ingest.py --dataset rvu
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from cms_pricing.ingestion.contracts.ingestor_spec import SourceFile  # noqa: E402
+from cms_pricing.ingestion.ingestors.rvu_ingestor import RVUIngestor  # noqa: E402
+from cms_pricing.ingestion.scrapers.cms_rvu_scraper import (  # noqa: E402
+    CMSRVUScraper,
+    RVUFileInfo,
+)
+
+
+QUARTER_ORDER = {"A": 1, "B": 2, "C": 3, "D": 4}
+DEFAULT_REQUIRED_RVU_DATASETS = (
+    "pprrvu",
+    "gpci",
+    "oppscap",
+    "anescf",
+    "localitycounty",
+)
+
+
+class LiveCMSValidationError(RuntimeError):
+    """Raised when live CMS validation fails an acceptance invariant."""
+
+
+@dataclass
+class LiveCMSValidationConfig:
+    dataset: str = "rvu"
+    start_year: int = field(default_factory=lambda: date.today().year)
+    end_year: int = field(default_factory=lambda: date.today().year)
+    release: str = "latest"
+    output_dir: Path = PROJECT_ROOT / "data" / "live_cms_validation"
+    report_json: Optional[Path] = None
+    min_total_records: int = 1
+    required_datasets: Tuple[str, ...] = DEFAULT_REQUIRED_RVU_DATASETS
+
+
+class RecordingSnapshotService:
+    """Snapshot service stub that records registrations without DB writes."""
+
+    def __init__(self) -> None:
+        self.registered: List[Dict[str, Any]] = []
+        self.db = _RecordingSnapshotDb()
+
+    def register_snapshot(
+        self,
+        dataset_id: str,
+        release_id: str,
+        digest: str,
+        effective_from: date,
+        effective_to: Optional[date] = None,
+        manifest_url: Optional[str] = None,
+        curated_path: Optional[str] = None,
+        autocommit: bool = True,
+    ) -> None:
+        self.registered.append(
+            {
+                "dataset_id": dataset_id,
+                "release_id": release_id,
+                "digest": digest,
+                "effective_from": effective_from.isoformat(),
+                "effective_to": effective_to.isoformat() if effective_to else None,
+                "manifest_url": manifest_url,
+                "curated_path": curated_path,
+                "autocommit": autocommit,
+            }
+        )
+
+    def close(self) -> None:
+        pass
+
+
+class _RecordingSnapshotDb:
+    def begin(self) -> "_RecordingSnapshotDb":
+        return self
+
+    def __enter__(self) -> "_RecordingSnapshotDb":
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> bool:
+        return False
+
+
+def _release_sort_key(file_info: RVUFileInfo) -> Tuple[int, int, str]:
+    return (
+        file_info.year,
+        QUARTER_ORDER.get((file_info.quarter or "").upper(), 0),
+        (file_info.revision or ""),
+    )
+
+
+def _release_id_for(file_info: RVUFileInfo) -> str:
+    suffix = f"{file_info.quarter.upper()}{file_info.revision or ''}"
+    return f"rvu_{file_info.year}_{suffix}"
+
+
+def _compact_release_id_for(file_info: RVUFileInfo) -> str:
+    suffix = f"{file_info.quarter.lower()}{(file_info.revision or '').lower()}"
+    return f"rvu{file_info.year % 100:02d}{suffix}"
+
+
+def _release_aliases(file_info: RVUFileInfo) -> set[str]:
+    standard = _release_id_for(file_info)
+    compact = _compact_release_id_for(file_info)
+    return {
+        standard.lower(),
+        standard.replace("_", "").lower(),
+        compact.lower(),
+        compact.removeprefix("rvu").lower(),
+    }
+
+
+def select_release_files(files: Sequence[RVUFileInfo], release: str) -> List[RVUFileInfo]:
+    """Select all files belonging to a requested release or the latest release."""
+    if not files:
+        raise LiveCMSValidationError("CMS RVU discovery returned no files")
+
+    if release.lower() == "latest":
+        selected_key = max(_release_sort_key(file_info) for file_info in files)
+        return [file_info for file_info in files if _release_sort_key(file_info) == selected_key]
+
+    requested = release.lower().replace("-", "_")
+    matches = [
+        file_info
+        for file_info in files
+        if requested in _release_aliases(file_info)
+        or requested.replace("_", "") in _release_aliases(file_info)
+    ]
+    if not matches:
+        available = sorted({_release_id_for(file_info) for file_info in files})
+        raise LiveCMSValidationError(
+            f"Requested release {release!r} not found. Available releases: {available}"
+        )
+    return matches
+
+
+def source_file_from_rvu_info(file_info: RVUFileInfo) -> SourceFile:
+    metadata = {
+        "detail_url": file_info.detail_url,
+        "display_name": file_info.display_name,
+        "posted_at": file_info.posted_at,
+        "version": file_info.version,
+        "year": file_info.year,
+        "quarter": file_info.quarter,
+        "revision": file_info.revision,
+        **dict(file_info.metadata or {}),
+    }
+    return SourceFile(
+        url=file_info.url,
+        filename=file_info.filename,
+        content_type=file_info.content_type or "application/octet-stream",
+        expected_size_bytes=file_info.size_bytes,
+        last_modified=file_info.last_modified,
+        checksum=file_info.checksum,
+        file_type=file_info.file_type,
+        metadata=metadata,
+    )
+
+
+def _file_summary(file_info: RVUFileInfo) -> Dict[str, Any]:
+    return {
+        "url": file_info.url,
+        "filename": file_info.filename,
+        "content_type": file_info.content_type,
+        "file_type": file_info.file_type,
+        "size_bytes": file_info.size_bytes,
+        "year": file_info.year,
+        "quarter": file_info.quarter,
+        "revision": file_info.revision,
+        "posted_at": file_info.posted_at,
+        "detail_url": file_info.detail_url,
+        "display_name": file_info.display_name,
+        "version": file_info.version,
+    }
+
+
+def _normalize_paths(mapping: Dict[str, Any]) -> Dict[str, Optional[str]]:
+    return {
+        key: str(value) if value is not None else None
+        for key, value in mapping.items()
+    }
+
+
+def _write_report(path: Path, report: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _assert_stage_success(stage_name: str, result: Dict[str, Any]) -> None:
+    if result.get("status") != "success":
+        raise LiveCMSValidationError(
+            f"{stage_name} stage failed: {result.get('error') or result}"
+        )
+
+
+def _assert_normalize_invariants(
+    normalize_result: Dict[str, Any],
+    required_datasets: Iterable[str],
+) -> None:
+    row_counts = normalize_result.get("dataset_row_counts") or {}
+    missing = [dataset for dataset in required_datasets if row_counts.get(dataset, 0) <= 0]
+    if missing:
+        raise LiveCMSValidationError(
+            f"Normalize stage missing required positive datasets: {missing}; row_counts={row_counts}"
+        )
+
+    schema_validation = normalize_result.get("schema_validation") or {}
+    errors = schema_validation.get("errors") or []
+    if errors:
+        raise LiveCMSValidationError(f"Schema validation errors: {errors}")
+
+    validation_results = schema_validation.get("validation_results") or {}
+    invalid = [
+        dataset
+        for dataset, result in validation_results.items()
+        if not result.get("valid", False)
+    ]
+    if invalid:
+        raise LiveCMSValidationError(f"Invalid schema validation results: {invalid}")
+
+
+def _assert_publish_invariants(
+    publish_result: Dict[str, Any],
+    required_datasets: Iterable[str],
+    min_total_records: int,
+) -> None:
+    record_count = int(publish_result.get("record_count") or 0)
+    if record_count < min_total_records:
+        raise LiveCMSValidationError(
+            f"Published record count {record_count} is below minimum {min_total_records}"
+        )
+
+    curated_tables = publish_result.get("curated_tables") or {}
+    missing_curated = [
+        dataset for dataset in required_datasets if not curated_tables.get(dataset)
+    ]
+    if missing_curated:
+        raise LiveCMSValidationError(
+            f"Publish stage missing curated parquet paths for: {missing_curated}"
+        )
+
+
+async def run_live_rvu_validation(config: LiveCMSValidationConfig) -> Dict[str, Any]:
+    started_at = datetime.now(timezone.utc)
+    output_dir = Path(config.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report_path = config.report_json or (
+        output_dir / f"live_cms_rvu_validation_{started_at:%Y%m%d_%H%M%S}.json"
+    )
+
+    report: Dict[str, Any] = {
+        "status": "running",
+        "dataset": config.dataset,
+        "started_at": started_at.isoformat(),
+        "config": {
+            "start_year": config.start_year,
+            "end_year": config.end_year,
+            "release": config.release,
+            "output_dir": str(output_dir),
+            "required_datasets": list(config.required_datasets),
+            "min_total_records": config.min_total_records,
+            "db_writes_enabled": False,
+        },
+    }
+
+    try:
+        scraper = CMSRVUScraper(output_dir=str(output_dir / "discovery"))
+        discovered_files = await scraper.scrape_rvu_files(
+            start_year=config.start_year,
+            end_year=config.end_year,
+        )
+        selected_files = select_release_files(discovered_files, config.release)
+        selected_release_id = _release_id_for(selected_files[0])
+        source_files = [source_file_from_rvu_info(file_info) for file_info in selected_files]
+
+        report["discovery"] = {
+            "manifest_path": str(scraper.last_manifest_path) if scraper.last_manifest_path else None,
+            "discovered_file_count": len(discovered_files),
+            "available_releases": sorted({_release_id_for(file_info) for file_info in discovered_files}),
+            "selected_release_id": selected_release_id,
+            "selected_files": [_file_summary(file_info) for file_info in selected_files],
+        }
+
+        ingestor = RVUIngestor(str(output_dir / "ingested"))
+        try:
+            ingestor.snapshot_service.close()
+        except Exception:
+            pass
+        snapshot_service = RecordingSnapshotService()
+        ingestor.snapshot_service = snapshot_service
+        ingestor._snapshot_service_managed_session = False
+
+        batch_id = f"live-cms-rvu-{int(time.time())}"
+        land = await ingestor._land_stage(
+            release_id=selected_release_id,
+            batch_id=batch_id,
+            source_files=source_files,
+        )
+        _assert_stage_success("land", land)
+
+        raw_batch = land["raw_batch"]
+        validate = await ingestor._validate_stage(raw_batch)
+        _assert_stage_success("validate", validate)
+
+        normalize = await ingestor._normalize_stage(validate, raw_batch)
+        _assert_stage_success("normalize", normalize)
+        _assert_normalize_invariants(normalize, config.required_datasets)
+
+        enrich = await ingestor._enrich_stage(normalize)
+        _assert_stage_success("enrich", enrich)
+
+        publish = await ingestor._publish_stage(enrich)
+        _assert_stage_success("publish", publish)
+        _assert_publish_invariants(
+            publish,
+            config.required_datasets,
+            config.min_total_records,
+        )
+
+        schema_validation = normalize.get("schema_validation") or {}
+        report["stages"] = {
+            "land": {
+                "files_downloaded": land.get("files_downloaded"),
+                "manifest_path": land.get("manifest_path"),
+                "docs_manifest_path": land.get("docs_manifest_path"),
+                "total_size_bytes": land.get("total_size_bytes"),
+            },
+            "validate": {
+                "quality_score": validate.get("quality_score"),
+                "total_records": validate.get("total_records"),
+                "valid_records": validate.get("valid_records"),
+                "rejected_records": validate.get("rejected_records"),
+            },
+            "normalize": {
+                "normalized_records": normalize.get("normalized_records"),
+                "dataset_row_counts": normalize.get("dataset_row_counts"),
+                "parser_rejects": (normalize.get("metadata") or {}).get("parser_rejects", {}),
+                "schema_validation": {
+                    "quality_score": schema_validation.get("quality_score"),
+                    "total_records": schema_validation.get("total_records"),
+                    "valid_records": schema_validation.get("valid_records"),
+                    "rejected_records": schema_validation.get("rejected_records"),
+                    "errors": schema_validation.get("errors", []),
+                    "warnings": schema_validation.get("warnings", []),
+                },
+            },
+            "enrich": {
+                "record_count": enrich.get("record_count"),
+                "mapping_confidence": enrich.get("mapping_confidence"),
+                "reference_data_used": enrich.get("reference_data_used", []),
+            },
+            "publish": {
+                "record_count": publish.get("record_count"),
+                "curated_directory": publish.get("curated_directory"),
+                "curated_tables": _normalize_paths(publish.get("curated_tables") or {}),
+                "database_load_results": publish.get("database_load_results", {}),
+                "snapshot_registrations": snapshot_service.registered,
+            },
+        }
+        report["status"] = "success"
+        return report
+    except Exception as exc:
+        report["status"] = "failed"
+        report["error"] = str(exc)
+        raise
+    finally:
+        completed_at = datetime.now(timezone.utc)
+        report["completed_at"] = completed_at.isoformat()
+        report["duration_seconds"] = round((completed_at - started_at).total_seconds(), 3)
+        report["report_path"] = str(report_path)
+        _write_report(report_path, report)
+
+
+async def run_live_validation(config: LiveCMSValidationConfig) -> Dict[str, Any]:
+    if config.dataset != "rvu":
+        raise LiveCMSValidationError(
+            f"Unsupported dataset {config.dataset!r}; only 'rvu' is implemented"
+        )
+    return await run_live_rvu_validation(config)
+
+
+def _parse_required_datasets(value: str) -> Tuple[str, ...]:
+    return tuple(item.strip() for item in value.split(",") if item.strip())
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    current_year = date.today().year
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dataset", choices=["rvu"], default="rvu")
+    parser.add_argument("--start-year", type=int, default=current_year)
+    parser.add_argument("--end-year", type=int, default=current_year)
+    parser.add_argument(
+        "--release",
+        default="latest",
+        help="Release to validate, e.g. latest, rvu_2025_A, rvu25a.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=PROJECT_ROOT / "data" / "live_cms_validation",
+    )
+    parser.add_argument("--report-json", type=Path)
+    parser.add_argument("--min-total-records", type=int, default=1)
+    parser.add_argument(
+        "--required-datasets",
+        default=",".join(DEFAULT_REQUIRED_RVU_DATASETS),
+        help="Comma-separated normalized dataset keys that must be present.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Run without ENABLE_LIVE_CMS=1. Intended for manual use only.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+    if os.getenv("ENABLE_LIVE_CMS") != "1" and not args.force:
+        print(
+            "Live CMS validation is disabled. Set ENABLE_LIVE_CMS=1 or pass --force.",
+            file=sys.stderr,
+        )
+        return 2
+
+    config = LiveCMSValidationConfig(
+        dataset=args.dataset,
+        start_year=args.start_year,
+        end_year=args.end_year,
+        release=args.release,
+        output_dir=args.output_dir,
+        report_json=args.report_json,
+        min_total_records=args.min_total_records,
+        required_datasets=_parse_required_datasets(args.required_datasets),
+    )
+
+    try:
+        report = asyncio.run(run_live_validation(config))
+    except Exception as exc:
+        print(f"Live CMS validation failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, indent=2, sort_keys=True))
+    print(f"Report written to {report['report_path']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ingestion/test_anes_parser_golden.py
+++ b/tests/ingestion/test_anes_parser_golden.py
@@ -520,3 +520,74 @@ def test_anes_date_from_filename_ANES25D():
     
     # Should still extract 2025 from filename pattern
     assert (result.data['effective_from'] == pd.to_datetime('2025-01-01')).all()
+
+
+def _anes_2026_fixed_width_line(
+    mac: str,
+    locality: str,
+    name: str,
+    qualifying_cents: str,
+    non_qualifying_cents: str,
+) -> str:
+    return (
+        f"{mac:<12}"
+        f"{locality:<6}"
+        f"{name:<49}"
+        f"{qualifying_cents:>4}"
+        "  "
+        f"{non_qualifying_cents:>4}"
+    )
+
+
+@pytest.mark.edge_case
+def test_anes_2026_txt_uses_non_qualifying_apm_cf():
+    """Current CMS 2026 ANES TXT includes qualifying and non-qualifying CFs."""
+    metadata = {
+        **TEST_METADATA,
+        "release_id": "test_anes26c",
+        "product_year": "2026",
+        "quarter_vintage": "C",
+        "vintage_date": datetime(2026, 7, 1),
+        "source_release": "RVU26C",
+    }
+    content = "\n".join(
+        [
+            _anes_2026_fixed_width_line("10112", "00", "ALABAMA", "1963", "1953"),
+            _anes_2026_fixed_width_line("02102", "01", "ALASKA", "2829", "2815"),
+        ]
+    )
+
+    result = parse_anes(BytesIO(content.encode("utf-8")), "ANES2026.txt", metadata)
+
+    assert len(result.data) == 2
+    alabama = result.data[result.data["mac"] == "10112"].iloc[0]
+    alaska = result.data[result.data["mac"] == "02102"].iloc[0]
+    assert alabama["anesthesia_cf_usd"] == 19.53
+    assert alaska["anesthesia_cf_usd"] == 28.15
+    assert pd.to_datetime(alabama["effective_from"]) == pd.Timestamp("2026-01-01")
+
+
+@pytest.mark.edge_case
+def test_anes_2026_csv_uses_non_qualifying_apm_cf_header():
+    """Current CMS 2026 ANES CSV has separate qualifying/non-qualifying columns."""
+    metadata = {
+        **TEST_METADATA,
+        "release_id": "test_anes26c_csv",
+        "product_year": "2026",
+        "quarter_vintage": "C",
+        "vintage_date": datetime(2026, 7, 1),
+        "source_release": "RVU26C",
+    }
+    content = (
+        "Contractor,Locality,Locality Name,"
+        "Qualifying APM National Anes CF (with 2.5% statutory increase) of 20.599835,"
+        "Non-Qualifying APM National Anes CF (with 2.5% Statutory increase)  of 20.49754\n"
+        "10112 ,00 ,ALABAMA,19.63,19.53\n"
+        "02102 ,01 ,ALASKA*,28.29,28.15\n"
+    )
+
+    result = parse_anes(BytesIO(content.encode("utf-8")), "ANES2026.csv", metadata)
+
+    assert len(result.data) == 2
+    assert set(result.data["anesthesia_cf_usd"]) == {19.53, 28.15}
+    assert "anesthesia_cf_qp_raw" in result.data.columns

--- a/tests/ingestion/test_gpci_parser_golden.py
+++ b/tests/ingestion/test_gpci_parser_golden.py
@@ -195,11 +195,11 @@ def test_gpci_golden_xlsx(fixtures_dir):
     
     # Split range checks for clarity (per user guidance)
     assert (gpci_work >= 0.20).all(), "All gpci_work values should be >= 0.20"
-    assert (gpci_work <= 2.50).all(), "All gpci_work values should be <= 2.50"
+    assert (gpci_work <= 2.75).all(), "All gpci_work values should be <= 2.75"
     assert (gpci_pe >= 0.20).all(), "All gpci_pe values should be >= 0.20"
-    assert (gpci_pe <= 2.50).all(), "All gpci_pe values should be <= 2.50"
+    assert (gpci_pe <= 2.75).all(), "All gpci_pe values should be <= 2.75"
     assert (gpci_mp >= 0.20).all(), "All gpci_mp values should be >= 0.20"
-    assert (gpci_mp <= 2.50).all(), "All gpci_mp values should be <= 2.50"
+    assert (gpci_mp <= 2.75).all(), "All gpci_mp values should be <= 2.75"
     
     # Verify metrics
     assert result.metrics['locality_count'] == len(result.data)
@@ -414,8 +414,8 @@ def test_gpci_metrics_structure(fixtures_dir):
     assert 'mp_max' in stats
     
     # Verify reasonable values
-    assert 0.20 <= stats['work_min'] <= 2.50
-    assert 0.20 <= stats['work_max'] <= 2.50
+    assert 0.20 <= stats['work_min'] <= 2.75
+    assert 0.20 <= stats['work_max'] <= 2.75
 
 
 # ============================================================================
@@ -506,3 +506,52 @@ def test_gpci_real_cms_duplicate_locality_00(fixtures_dir):
     locality_00_macs = set(locality_00_rows['mac'])
     assert len(locality_00_macs) == 2, \
         "Locality 00 rows should have different MACs (not true duplicates)"
+
+
+@pytest.mark.edge_case
+@pytest.mark.gpci
+def test_gpci_2026_year_prefixed_headers_and_tab_delimited_txt():
+    """Current CMS 2026 GPCI files use year-prefixed headers and tab TXT."""
+    rows = []
+    for idx in range(100):
+        mp_gpci = "2.529" if idx == 0 else "0.296" if idx == 1 else "0.566"
+        rows.append(
+            "\t".join(
+                [
+                    f"{10000 + idx:05d}",
+                    "AL",
+                    f"{idx % 99:02d}",
+                    f"LOCALITY {idx}",
+                    "1.000",
+                    "0.875",
+                    mp_gpci,
+                ]
+            )
+        )
+    content = "\n".join(
+        [
+            "ADDENDUM E. FINAL CY 2026 GEOGRAPHIC PRACTICE COST INDICES (GPCIs) BY STATE AND MEDICARE LOCALITY\t\t\t\t\t\t",
+            "\t\t\t\t\t\t",
+            "Medicare Administrative Contractor (MAC)\tState\tLocality Number\tLocality Name\t2026 PW GPCI (with 1.0 Floor)***\t2026 PE GPCI\t2026 MP GPCI",
+            *rows,
+        ]
+    )
+    metadata = {
+        **TEST_METADATA,
+        "release_id": "test_rvu26c_gpci",
+        "product_year": "2026",
+        "quarter_vintage": "2026Q3",
+        "vintage_date": datetime(2026, 7, 1, 0, 0, 0),
+        "source_release": "RVU26C",
+    }
+
+    result = parse_gpci(BytesIO(content.encode("utf-8")), "GPCI2026.txt", metadata)
+
+    assert len(result.data) == 100
+    assert len(result.rejects) == 0
+    first = result.data.iloc[0]
+    assert first["gpci_work"] == "1.000"
+    assert first["gpci_pe"] == "0.875"
+    assert first["gpci_mp"] == "2.529"
+    assert pd.to_datetime(first["effective_from"]) == pd.Timestamp("2026-07-01")
+    assert "0.296" in set(result.data["gpci_mp"])

--- a/tests/ingestion/test_gpci_parser_negatives.py
+++ b/tests/ingestion/test_gpci_parser_negatives.py
@@ -43,9 +43,9 @@ def fixtures_dir():
 @pytest.mark.gpci
 def test_gpci_out_of_range_rejects(fixtures_dir):
     """
-    GPCI values outside hard bounds [0.20, 2.50] are rejected.
+    GPCI values outside hard bounds [0.20, 2.75] are rejected.
     
-    Fixture: GPCI work=3.0, PE=3.5 (above 2.50)
+    Fixture: GPCI work=3.0, PE=3.5 (above 2.75)
     Expected: Rows rejected with validation_error
     """
     fixture = fixtures_dir / 'out_of_range.csv'

--- a/tests/ingestion/test_live_cms_validation_harness.py
+++ b/tests/ingestion/test_live_cms_validation_harness.py
@@ -1,0 +1,150 @@
+import os
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from cms_pricing.ingestion.scrapers.cms_rvu_scraper import RVUFileInfo
+from scripts.validate_live_cms_ingest import (
+    LiveCMSValidationConfig,
+    RecordingSnapshotService,
+    main,
+    run_live_validation,
+    select_release_files,
+    source_file_from_rvu_info,
+)
+
+
+def _rvu_file(
+    *,
+    year: int,
+    quarter: str,
+    revision: str | None = None,
+    filename: str | None = None,
+) -> RVUFileInfo:
+    suffix = f"{quarter}{revision or ''}"
+    return RVUFileInfo(
+        url=f"https://www.cms.gov/files/zip/rvu{year % 100:02d}{suffix.lower()}.zip",
+        filename=filename or f"RVU{year % 100:02d}{suffix}.zip",
+        content_type="application/zip",
+        year=year,
+        quarter=quarter,
+        revision=revision,
+        posted_at=f"{year}-01-01",
+        file_size="1 MB",
+        detail_url=f"https://www.cms.gov/rvu-{year}-{suffix.lower()}",
+        display_name=f"RVU {year} {suffix}",
+        version=f"{year}{suffix}",
+        file_type="zip",
+        metadata={"source": "test"},
+        size_bytes=1234,
+        checksum="abc123",
+        last_modified=datetime(year, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+def test_select_release_files_latest_uses_highest_year_quarter_and_revision():
+    files = [
+        _rvu_file(year=2024, quarter="D"),
+        _rvu_file(year=2025, quarter="A"),
+        _rvu_file(year=2025, quarter="B"),
+        _rvu_file(year=2025, quarter="B", revision="1"),
+    ]
+
+    selected = select_release_files(files, "latest")
+
+    assert selected == [files[-1]]
+
+
+def test_select_release_files_accepts_standard_and_compact_release_ids():
+    files = [
+        _rvu_file(year=2025, quarter="A", filename="RVU25A.zip"),
+        _rvu_file(year=2025, quarter="B", filename="RVU25B.zip"),
+    ]
+
+    assert select_release_files(files, "rvu_2025_A") == [files[0]]
+    assert select_release_files(files, "rvu25b") == [files[1]]
+    assert select_release_files(files, "25a") == [files[0]]
+
+
+def test_source_file_from_rvu_info_preserves_download_metadata():
+    file_info = _rvu_file(year=2025, quarter="A")
+
+    source_file = source_file_from_rvu_info(file_info)
+
+    assert source_file.url == file_info.url
+    assert source_file.filename == file_info.filename
+    assert source_file.content_type == "application/zip"
+    assert source_file.expected_size_bytes == 1234
+    assert source_file.last_modified == file_info.last_modified
+    assert source_file.checksum == "abc123"
+    assert source_file.file_type == "zip"
+    assert source_file.metadata["detail_url"] == file_info.detail_url
+    assert source_file.metadata["year"] == 2025
+    assert source_file.metadata["quarter"] == "A"
+    assert source_file.metadata["source"] == "test"
+
+
+def test_recording_snapshot_service_supports_transactional_publish_contract():
+    service = RecordingSnapshotService()
+
+    with service.db.begin():
+        service.register_snapshot(
+            dataset_id="rvu_items",
+            release_id="rvu_2025_A",
+            digest="abc123",
+            effective_from=date(2025, 1, 1),
+            curated_path="/tmp/rvu.parquet",
+            autocommit=False,
+        )
+
+    assert service.registered == [
+        {
+            "dataset_id": "rvu_items",
+            "release_id": "rvu_2025_A",
+            "digest": "abc123",
+            "effective_from": "2025-01-01",
+            "effective_to": None,
+            "manifest_url": None,
+            "curated_path": "/tmp/rvu.parquet",
+            "autocommit": False,
+        }
+    ]
+
+
+def test_live_cms_script_requires_explicit_enablement(monkeypatch, capsys):
+    monkeypatch.delenv("ENABLE_LIVE_CMS", raising=False)
+
+    exit_code = main(["--dataset", "rvu"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "Live CMS validation is disabled" in captured.err
+
+
+@pytest.mark.live_cms
+@pytest.mark.ingestor
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    os.getenv("ENABLE_LIVE_CMS") != "1",
+    reason="set ENABLE_LIVE_CMS=1 to download and validate live CMS RVU files",
+)
+async def test_live_cms_rvu_latest_release_downloads_and_publishes(tmp_path: Path):
+    start_year = int(os.getenv("LIVE_CMS_START_YEAR", str(date.today().year)))
+    end_year = int(os.getenv("LIVE_CMS_END_YEAR", str(start_year)))
+
+    report = await run_live_validation(
+        LiveCMSValidationConfig(
+            dataset="rvu",
+            start_year=start_year,
+            end_year=end_year,
+            release=os.getenv("LIVE_CMS_RELEASE", "latest"),
+            output_dir=tmp_path / "live_cms_validation",
+            min_total_records=1,
+        )
+    )
+
+    assert report["status"] == "success"
+    assert report["discovery"]["selected_files"]
+    assert report["stages"]["publish"]["record_count"] > 0
+    assert report["stages"]["publish"]["snapshot_registrations"]


### PR DESCRIPTION
Adds an opt-in live CMS RVU validation harness and parser hardening found by running it against current CMS data. The live run discovered rvu_2026_C, downloaded the CMS zip, normalized all five required RVU datasets, passed schema validation, and published DB-free curated artifacts.\n\nKey changes:\n- Add scripts/validate_live_cms_ingest.py with ENABLE_LIVE_CMS opt-in guard and JSON reporting.\n- Add skipped-by-default live_cms pytest coverage plus non-network harness tests.\n- Support current 2026 GPCI year-prefixed tab/CSV headers and Q-style quarter effective dates.\n- Support 2026 ANES dual qualifying/non-qualifying APM headers/layout, using non-qualifying APM CF for the existing single-CF schema.\n- Widen GPCI hard schema bounds to accept official CMS 2026 C observed values while keeping 3.0+ invalid values rejected.\n\nValidation:\n- docker compose -p cms-api-fix exec api pytest tests/ingestion/test_live_cms_validation_harness.py tests/ingestion/test_rvu_real_cms_ingest_validation.py tests/ingestion/test_mpfs_real_cms_sample_validation.py tests/services/test_mpfs_component_pricing.py tests/services/test_pricing_provenance.py tests/api/test_health.py tests/api/test_plans.py tests/ingestion/test_pprrvu_parser.py tests/ingestion/test_gpci_parser_golden.py tests/ingestion/test_gpci_parser_negatives.py tests/ingestion/test_anes_parser_golden.py tests/ingestors/test_rvu_validation_fixes.py -> 92 passed, 1 skipped.\n- ENABLE_LIVE_CMS=1 python scripts/validate_live_cms_ingest.py --dataset rvu --start-year 2025 --end-year 2026 --release latest --output-dir data/live_cms_validation/manual-20260610-final2 -> success for rvu_2026_C, 34,953 normalized/published records, schema errors [].\n\nNote: PR #439 was already merged and its branch deleted, so this is a follow-up branch based on current main.