### PR TITLE
Add EOD tracker sync workflow

### DIFF
--- a/docs/workbench/CURRENT.md
+++ b/docs/workbench/CURRENT.md
@@ -1,0 +1,25 @@
+# CMS API Current Work
+
+_Generated from `state/work/` by `tools/work_tracker.py`. Do not edit by hand._
+
+- Active task WIP: **1/3**
+
+## Active Tasks
+
+### [1.1.1] Wire RVU Loaded Data Into Pricing Usage
+
+- Status: `active`
+- Roadmap: `CMS Data Pipeline`
+- Epic: `CMS RVU Ingestion And Snapshot Selection`
+- Team: `data`
+- Owner mode: `shared`
+- Updated: `2026-06-10`
+- Plan: [`docs/workbench/DOC-cms-rvu-local-db-load-status.md`](DOC-cms-rvu-local-db-load-status.md)
+- Current task: Confirm the API pricing path can use the live-loaded RVU and GPCI snapshots for valuation-date selection.
+- Next action: Run local API pricing smoke calls against the loaded rvu_2026_C data, then add a repeatable post-load smoke command if one is missing.
+- Resume from: Start from scripts/load_latest_cms_rvu_local.py, DatasetSnapshotService.select_snapshot, and the MPFS pricing service path.
+- Linked outputs: [`docs/workbench/DOC-cms-rvu-local-db-load-status.md`](DOC-cms-rvu-local-db-load-status.md)
+
+## Blocked Tasks
+
+- None.

--- a/docs/workbench/CURRENT.md
+++ b/docs/workbench/CURRENT.md
@@ -23,3 +23,7 @@ _Generated from `state/work/` by `tools/work_tracker.py`. Do not edit by hand._
 ## Blocked Tasks
 
 - None.
+
+## Queued For Merge
+
+- None.

--- a/docs/workbench/DOC-cms-rvu-local-db-load-status.md
+++ b/docs/workbench/DOC-cms-rvu-local-db-load-status.md
@@ -1,0 +1,77 @@
+# CMS RVU Local DB Load Status
+
+**Status:** Current
+**Updated:** 2026-06-10
+**Tracker link:** `state/work/tasks/load-latest-cms-rvu-local-db.yaml`
+
+## Completed
+
+The latest live CMS RVU release was loaded through the real local/dev database
+path, not the no-DB validation harness.
+
+| Check | Result |
+|---|---|
+| Selected release | `rvu_2026_C` |
+| CMS effective date | `2026-07-01` |
+| Run date | `2026-06-10` |
+| Snapshot date behavior | `dataset_snapshots.effective_from` uses the CMS effective date, not the run date |
+| Snapshot selection | `rvu_items -> rvu_2026_C`, `gpci_indices -> gpci_2026_C` for valuation date `2026-07-01` |
+| Commit | `fe76d98 Add local CMS RVU DB load command` |
+
+## Curated Parquet Evidence
+
+| Dataset | Rows |
+|---|---:|
+| `pprrvu` | 19358 |
+| `gpci` | 109 |
+| `oppscap` | 15260 |
+| `anescf` | 109 |
+| `localitycounty` | 117 |
+
+## Database Evidence
+
+| Table family | Rows loaded for release |
+|---|---:|
+| `pprrvu` | 19358 |
+| `gpci` | 109 |
+| `oppscap` | 15260 |
+| `anescf` | 109 |
+| `localitycounty` | 57 |
+
+The `localitycounty` DB count is lower than the curated parquet count because the
+current loader normalizes the source rows into the existing DB shape. It is
+positive and no longer collapses rows by MAC only. Exact locality row parity
+should be treated as follow-up if the downstream API needs county-level
+selection rather than locality-level selection.
+
+## Repeatable Command
+
+```bash
+docker compose -p cms-api-fix run --rm api \
+  python scripts/load_latest_cms_rvu_local.py \
+  --start-year 2026 \
+  --end-year 2026 \
+  --release latest \
+  --output-dir data/ingestion/local/rvu \
+  --report-json data/ingestion/local/reports/cms_rvu_local_load_latest.json
+```
+
+## Tests Run
+
+```bash
+.venv/bin/pytest \
+  tests/scripts/test_load_latest_cms_rvu_local.py \
+  tests/ingestors/test_rvu_loader_aliases.py \
+  tests/ingestion/test_rvu_real_cms_ingest_validation.py \
+  tests/ingestion/test_live_cms_validation_harness.py \
+  -q
+```
+
+Result: `24 passed, 1 skipped`.
+
+## Next
+
+The next useful task is to make the loaded RVU and GPCI data usable from the
+pricing workflow itself. Start by running local API pricing smoke calls against
+the loaded `rvu_2026_C` release and add a repeatable post-load smoke command if
+one is missing.

--- a/docs/workbench/ROADMAP.md
+++ b/docs/workbench/ROADMAP.md
@@ -1,0 +1,20 @@
+# CMS API Work Roadmap
+
+_Generated from `state/work/` by `tools/work_tracker.py`. Do not edit by hand._
+
+## [1] CMS Data Pipeline
+
+- Status: `active`
+- Team: `data`
+- Owner mode: `shared`
+- Updated: `2026-06-10`
+- Plan: `None`
+- Summary: Land, validate, normalize, enrich, publish, and select CMS reimbursement datasets for pricing.
+
+### Epics
+
+- [1] CMS RVU Ingestion And Snapshot Selection - `active` (1 active, 1 done)
+  Team: `data`
+  Plan: [`docs/workbench/DOC-cms-rvu-local-db-load-status.md`](DOC-cms-rvu-local-db-load-status.md)
+  Summary: Move live CMS RVU releases through real local/dev DB writes and ensure valuation-date snapshot lookup chooses the expected RVU and GPCI release.
+  Current tasks: Wire RVU Loaded Data Into Pricing Usage

--- a/planning/standards/WORK_TRACKER_STANDARD.md
+++ b/planning/standards/WORK_TRACKER_STANDARD.md
@@ -70,7 +70,7 @@ summary: "Short context for humans and agents."
 Epics also include `parent_id`, pointing to a roadmap. Tasks include `parent_id`,
 pointing to an epic.
 
-Active and blocked tasks must include:
+Active, blocked, and queued-for-merge tasks must include:
 
 - `current_task`
 - `next_action`
@@ -83,6 +83,7 @@ Allowed statuses:
 - `queued`
 - `active`
 - `blocked`
+- `queued_for_merge`
 - `parked`
 - `icebox`
 - `done`
@@ -103,12 +104,51 @@ Allowed owner modes:
 
 ## Operating Rule
 
-When a meaningful work session finishes, update the tracker before handing back:
+Code PRs ship code. End-of-day tracker sync PRs reconcile tracker truth.
 
-1. Mark completed tasks `done`.
-2. Add or update the next active task.
-3. Link the run evidence or status doc under `linked_outputs`.
-4. Rebuild generated views with `python tools/work_tracker.py build`.
-5. Validate with `python tools/work_tracker.py check`.
+During the day, agents may update tracker YAML locally for working context, but
+ordinary implementation PRs should not stage these files:
+
+- `state/work/**`
+- `state/plans/accepted.yaml`
+- `docs/workbench/CURRENT.md`
+- `docs/workbench/ROADMAP.md`
+
+If a PR changes tracker or governance behavior, use a dedicated tracker PR.
+
+## End-Of-Day Sync
+
+At end of day, create one tracker sync pass:
+
+1. Reconcile local task additions, status changes, evidence links, and resume
+   fields.
+2. Resolve duplicate task IDs and duplicate ranks.
+3. Run merge queue dry run.
+4. Rebuild tracker views once.
+5. Push a tracker-only PR.
+
+Commands:
+
+```bash
+python scripts/governance/check-work-tracker.py
+python scripts/governance/process_merge_queue.py --dry-run --json
+python scripts/governance/build-work-tracker.py
+git diff --check
+python tools/work_tracker.py check-views
+```
+
+## Conflict Avoidance
+
+New task IDs should be globally specific and action-object scoped, such as
+`load-latest-cms-rvu-local-db`, not generic names such as `add-health-command`.
+
+If duplicate ranks appear, keep main branch ordering stable and move the new
+local task to the next open rank in that epic.
+
+If `CURRENT.md` or `ROADMAP.md` conflicts, resolve tracker YAML first, then
+regenerate the views.
+
+If multiple agents touched the same epic, reconcile ranks and statuses in the
+end-of-day tracker PR before pushing.
 
 This keeps chat history from becoming the only record of what happened.

--- a/planning/standards/WORK_TRACKER_STANDARD.md
+++ b/planning/standards/WORK_TRACKER_STANDARD.md
@@ -1,0 +1,114 @@
+# Work Tracker Standard
+
+**Status:** Active
+**Owner:** ClearBill CMS API maintainers
+**Updated:** 2026-06-10
+
+## Purpose
+
+This repo uses a lightweight work tracker to preserve implementation status across
+Codex sessions, pull requests, and local validation runs.
+
+The tracker answers four questions:
+
+- What workstreams are active?
+- What initiatives belong to each workstream?
+- What exact task should an agent resume?
+- What evidence shows what has already been completed?
+
+## Source Of Truth
+
+Canonical tracker state lives in `state/work/`.
+
+Generated human views live in `docs/workbench/` and are rebuilt from the state files.
+Do not hand-edit generated views.
+
+```
+state/work/
+  roadmaps/
+  epics/
+  tasks/
+
+docs/workbench/
+  ROADMAP.md
+  CURRENT.md
+```
+
+Long-form status notes and run evidence can live in `docs/workbench/DOC-*.md`.
+Those docs are evidence and context. The current work state remains in
+`state/work/`.
+
+## Record Levels
+
+Use `roadmap` for a durable workstream, such as CMS data pipeline hardening.
+
+Use `epic` for a bounded initiative under a roadmap, such as getting live CMS RVU
+data through ingest, publish, and pricing selection.
+
+Use `task` for one actionable execution slice with a clear resume point.
+
+## Required Fields
+
+Every roadmap, epic, and task record uses this base shape:
+
+```yaml
+id: cms-data-pipeline
+title: CMS Data Pipeline
+status: active
+rank: 1
+team: system
+owner_mode: shared
+updated_at: "2026-06-10"
+plan_path: null
+related_paths:
+  - "cms_pricing/ingestion"
+linked_beads:
+linked_outputs:
+summary: "Short context for humans and agents."
+```
+
+Epics also include `parent_id`, pointing to a roadmap. Tasks include `parent_id`,
+pointing to an epic.
+
+Active and blocked tasks must include:
+
+- `current_task`
+- `next_action`
+- `resume_from`
+
+## Status Values
+
+Allowed statuses:
+
+- `queued`
+- `active`
+- `blocked`
+- `parked`
+- `icebox`
+- `done`
+
+Allowed teams:
+
+- `system`
+- `data`
+- `api`
+- `ops`
+- `shared`
+
+Allowed owner modes:
+
+- `alex`
+- `agent`
+- `shared`
+
+## Operating Rule
+
+When a meaningful work session finishes, update the tracker before handing back:
+
+1. Mark completed tasks `done`.
+2. Add or update the next active task.
+3. Link the run evidence or status doc under `linked_outputs`.
+4. Rebuild generated views with `python tools/work_tracker.py build`.
+5. Validate with `python tools/work_tracker.py check`.
+
+This keeps chat history from becoming the only record of what happened.

--- a/scripts/governance/build-work-tracker.py
+++ b/scripts/governance/build-work-tracker.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""Validate CMS API work tracker state and rebuild generated views."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tools.work_tracker import build_command  # noqa: E402
+
+
+def main() -> int:
+    return build_command(ROOT)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/governance/check-work-tracker.py
+++ b/scripts/governance/check-work-tracker.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""Validate CMS API work tracker state."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tools.work_tracker import check_command  # noqa: E402
+
+
+def main() -> int:
+    return check_command(ROOT)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/governance/process_merge_queue.py
+++ b/scripts/governance/process_merge_queue.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Inspect queued-for-merge work tracker tasks for end-of-day sync."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tools.work_tracker import load_tracker, validate_tracker  # noqa: E402
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report queued tasks without changing files.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON output.")
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Reserved for future automated queue closeout; currently reports only.",
+    )
+    return parser.parse_args(argv)
+
+
+def queued_for_merge_payload() -> dict[str, Any]:
+    tracker = load_tracker(ROOT)
+    validation = validate_tracker(tracker)
+    candidates = [
+        {
+            "id": task["id"],
+            "title": task["title"],
+            "parent_id": task["parent_id"],
+            "updated_at": task["updated_at"],
+            "current_task": task.get("current_task"),
+            "next_action": task.get("next_action"),
+            "resume_from": task.get("resume_from"),
+        }
+        for task in tracker.tasks
+        if task.get("status") == "queued_for_merge"
+    ]
+    return {
+        "status": "error" if validation.errors else "ok",
+        "errors": validation.errors,
+        "warnings": validation.warnings,
+        "queued_for_merge_count": len(candidates),
+        "candidates": candidates,
+        "applied": False,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    payload = queued_for_merge_payload()
+    if args.apply and payload["queued_for_merge_count"]:
+        payload["status"] = "manual_review_required"
+        payload["warnings"] = [
+            *payload["warnings"],
+            "--apply is not automated yet; reconcile queued_for_merge tasks in YAML during EOD sync.",
+        ]
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(f"Queued-for-merge tasks: {payload['queued_for_merge_count']}")
+        for candidate in payload["candidates"]:
+            print(f"- {candidate['id']}: {candidate['title']}")
+        for error in payload["errors"]:
+            print(f"ERROR: {error}", file=sys.stderr)
+        for warning in payload["warnings"]:
+            print(f"WARN: {warning}")
+
+    return 1 if payload["errors"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/state/work/epics/cms-rvu-ingestion.yaml
+++ b/state/work/epics/cms-rvu-ingestion.yaml
@@ -1,0 +1,18 @@
+id: cms-rvu-ingestion
+parent_id: cms-data-pipeline
+title: CMS RVU Ingestion And Snapshot Selection
+status: active
+rank: 1
+team: data
+owner_mode: shared
+updated_at: "2026-06-10"
+plan_path: "docs/workbench/DOC-cms-rvu-local-db-load-status.md"
+related_paths:
+  - "cms_pricing/ingestion/ingestors/rvu_ingestor.py"
+  - "cms_pricing/ingestion/datasets/rvu_loaders.py"
+  - "cms_pricing/services/dataset_snapshot_service.py"
+  - "scripts/load_latest_cms_rvu_local.py"
+linked_beads:
+linked_outputs:
+  - "docs/workbench/DOC-cms-rvu-local-db-load-status.md"
+summary: "Move live CMS RVU releases through real local/dev DB writes and ensure valuation-date snapshot lookup chooses the expected RVU and GPCI release."

--- a/state/work/roadmaps/cms-data-pipeline.yaml
+++ b/state/work/roadmaps/cms-data-pipeline.yaml
@@ -1,0 +1,15 @@
+id: cms-data-pipeline
+title: CMS Data Pipeline
+status: active
+rank: 1
+team: data
+owner_mode: shared
+updated_at: "2026-06-10"
+plan_path: null
+related_paths:
+  - "cms_pricing/ingestion"
+  - "scripts"
+linked_beads:
+linked_outputs:
+  - "docs/workbench/DOC-cms-rvu-local-db-load-status.md"
+summary: "Land, validate, normalize, enrich, publish, and select CMS reimbursement datasets for pricing."

--- a/state/work/tasks/load-latest-cms-rvu-local-db.yaml
+++ b/state/work/tasks/load-latest-cms-rvu-local-db.yaml
@@ -1,0 +1,21 @@
+id: load-latest-cms-rvu-local-db
+parent_id: cms-rvu-ingestion
+title: Load Latest CMS RVU Into Local DB
+status: done
+rank: 2
+team: data
+owner_mode: agent
+updated_at: "2026-06-10"
+plan_path: "docs/workbench/DOC-cms-rvu-local-db-load-status.md"
+related_paths:
+  - "scripts/load_latest_cms_rvu_local.py"
+  - "cms_pricing/ingestion/datasets/rvu_loaders.py"
+  - "tests/scripts/test_load_latest_cms_rvu_local.py"
+  - "tests/ingestors/test_rvu_loader_aliases.py"
+linked_beads:
+linked_outputs:
+  - "docs/workbench/DOC-cms-rvu-local-db-load-status.md"
+summary: "Real DB RVU load command added, 2026 C live release loaded locally, snapshot effective dates verified, and locality-preserving DB dedupe fixed."
+current_task: "Completed in commit fe76d98."
+next_action: "Use the loader command for repeatable local/dev RVU refreshes."
+resume_from: "See docs/workbench/DOC-cms-rvu-local-db-load-status.md for row counts, selected release, and verification notes."

--- a/state/work/tasks/wire-rvu-loaded-data-into-pricing-usage.yaml
+++ b/state/work/tasks/wire-rvu-loaded-data-into-pricing-usage.yaml
@@ -1,0 +1,21 @@
+id: wire-rvu-loaded-data-into-pricing-usage
+parent_id: cms-rvu-ingestion
+title: Wire RVU Loaded Data Into Pricing Usage
+status: active
+rank: 1
+team: data
+owner_mode: shared
+updated_at: "2026-06-10"
+plan_path: "docs/workbench/DOC-cms-rvu-local-db-load-status.md"
+related_paths:
+  - "scripts/load_latest_cms_rvu_local.py"
+  - "cms_pricing/services/dataset_snapshot_service.py"
+  - "cms_pricing/services/pricing.py"
+  - "cms_pricing/engines/mpfs.py"
+linked_beads:
+linked_outputs:
+  - "docs/workbench/DOC-cms-rvu-local-db-load-status.md"
+summary: "Make the loaded RVU and GPCI release usable by local pricing smoke flows, not just ingestion verification."
+current_task: "Confirm the API pricing path can use the live-loaded RVU and GPCI snapshots for valuation-date selection."
+next_action: "Run local API pricing smoke calls against the loaded rvu_2026_C data, then add a repeatable post-load smoke command if one is missing."
+resume_from: "Start from scripts/load_latest_cms_rvu_local.py, DatasetSnapshotService.select_snapshot, and the MPFS pricing service path."

--- a/tests/tools/test_work_tracker.py
+++ b/tests/tools/test_work_tracker.py
@@ -4,6 +4,7 @@ from textwrap import dedent
 from tools.work_tracker import (
     build_current_view,
     build_roadmap_view,
+    check_views_command,
     load_tracker,
     validate_tracker,
     write_views,
@@ -107,6 +108,34 @@ def test_write_views_creates_generated_files(tmp_path):
     assert "Generated from `state/work/`" in (
         tmp_path / "docs/workbench/CURRENT.md"
     ).read_text(encoding="utf-8")
+
+
+def test_check_views_detects_generated_view_drift(tmp_path):
+    _seed_minimal_tracker(tmp_path)
+    tracker = load_tracker(tmp_path)
+    write_views(tracker)
+    (tmp_path / "docs/workbench/CURRENT.md").write_text("stale\n", encoding="utf-8")
+
+    assert check_views_command(tmp_path) == 1
+
+
+def test_queued_for_merge_tasks_are_valid_and_rendered(tmp_path):
+    _seed_minimal_tracker(tmp_path)
+    task_path = tmp_path / "state/work/tasks/use-rvu.yaml"
+    task_path.write_text(
+        task_path.read_text(encoding="utf-8").replace(
+            "status: active", "status: queued_for_merge"
+        ),
+        encoding="utf-8",
+    )
+
+    tracker = load_tracker(tmp_path)
+    result = validate_tracker(tracker)
+
+    assert result.errors == []
+    current = build_current_view(tracker)
+    assert "## Queued For Merge" in current
+    assert "Use RVU" in current
 
 
 def test_repo_tracker_state_is_valid():

--- a/tests/tools/test_work_tracker.py
+++ b/tests/tools/test_work_tracker.py
@@ -1,0 +1,118 @@
+from pathlib import Path
+from textwrap import dedent
+
+from tools.work_tracker import (
+    build_current_view,
+    build_roadmap_view,
+    load_tracker,
+    validate_tracker,
+    write_views,
+)
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(dedent(text).strip() + "\n", encoding="utf-8")
+
+
+def _seed_minimal_tracker(root: Path) -> None:
+    _write(root / "docs/workbench/DOC-status.md", "# Status\n")
+    _write(root / "cms_pricing/ingestion/.keep", "")
+    _write(
+        root / "state/work/roadmaps/data-pipeline.yaml",
+        """
+        id: data-pipeline
+        title: Data Pipeline
+        status: active
+        rank: 1
+        team: data
+        owner_mode: shared
+        updated_at: "2026-06-10"
+        plan_path: null
+        related_paths:
+          - "cms_pricing/ingestion"
+        linked_beads:
+        linked_outputs:
+          - "docs/workbench/DOC-status.md"
+        summary: "Pipeline work."
+        """,
+    )
+    _write(
+        root / "state/work/epics/rvu.yaml",
+        """
+        id: rvu
+        parent_id: data-pipeline
+        title: RVU
+        status: active
+        rank: 1
+        team: data
+        owner_mode: shared
+        updated_at: "2026-06-10"
+        plan_path: "docs/workbench/DOC-status.md"
+        related_paths:
+          - "cms_pricing/ingestion"
+        linked_beads:
+        linked_outputs:
+          - "docs/workbench/DOC-status.md"
+        summary: "RVU work."
+        """,
+    )
+    _write(
+        root / "state/work/tasks/use-rvu.yaml",
+        """
+        id: use-rvu
+        parent_id: rvu
+        title: Use RVU
+        status: active
+        rank: 1
+        team: data
+        owner_mode: shared
+        updated_at: "2026-06-10"
+        plan_path: "docs/workbench/DOC-status.md"
+        related_paths:
+          - "cms_pricing/ingestion"
+        linked_beads:
+        linked_outputs:
+          - "docs/workbench/DOC-status.md"
+        current_task: "Run pricing smoke."
+        next_action: "Call pricing endpoint."
+        resume_from: "Use loaded RVU data."
+        """,
+    )
+
+
+def test_tracker_validates_and_renders_temp_state(tmp_path):
+    _seed_minimal_tracker(tmp_path)
+
+    tracker = load_tracker(tmp_path)
+    result = validate_tracker(tracker)
+
+    assert result.errors == []
+    roadmap = build_roadmap_view(tracker)
+    current = build_current_view(tracker)
+    assert "Data Pipeline" in roadmap
+    assert "Use RVU" in current
+
+
+def test_write_views_creates_generated_files(tmp_path):
+    _seed_minimal_tracker(tmp_path)
+    tracker = load_tracker(tmp_path)
+
+    written = write_views(tracker)
+
+    assert {path.relative_to(tmp_path).as_posix() for path in written} == {
+        "docs/workbench/ROADMAP.md",
+        "docs/workbench/CURRENT.md",
+    }
+    assert "Generated from `state/work/`" in (
+        tmp_path / "docs/workbench/CURRENT.md"
+    ).read_text(encoding="utf-8")
+
+
+def test_repo_tracker_state_is_valid():
+    repo_root = Path(__file__).resolve().parents[2]
+    tracker = load_tracker(repo_root)
+
+    result = validate_tracker(tracker)
+
+    assert result.errors == []

--- a/tools/work_tracker.py
+++ b/tools/work_tracker.py
@@ -1,0 +1,530 @@
+#!/usr/bin/env python3
+"""Validate and render the repo-native CMS API work tracker."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+STATE_DIR = Path("state/work")
+ROADMAPS_DIR = STATE_DIR / "roadmaps"
+EPICS_DIR = STATE_DIR / "epics"
+TASKS_DIR = STATE_DIR / "tasks"
+ROADMAP_VIEW = Path("docs/workbench/ROADMAP.md")
+CURRENT_VIEW = Path("docs/workbench/CURRENT.md")
+
+STATUSES = {"queued", "active", "blocked", "parked", "icebox", "done"}
+OWNER_MODES = {"alex", "agent", "shared"}
+TEAMS = {"system", "data", "api", "ops", "shared"}
+ACTIVE_TASK_LIMIT = 3
+STATUS_ORDER = {
+    "active": 0,
+    "blocked": 1,
+    "queued": 2,
+    "parked": 3,
+    "icebox": 4,
+    "done": 5,
+}
+KIND_ORDER = ("roadmaps", "epics", "tasks")
+SLUG_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+
+@dataclass
+class ValidationResult:
+    errors: list[str]
+    warnings: list[str]
+
+
+@dataclass
+class TrackerData:
+    root: Path
+    roadmaps: list[dict[str, Any]]
+    epics: list[dict[str, Any]]
+    tasks: list[dict[str, Any]]
+
+    @property
+    def roadmaps_by_id(self) -> dict[str, dict[str, Any]]:
+        return {record["id"]: record for record in self.roadmaps}
+
+    @property
+    def epics_by_id(self) -> dict[str, dict[str, Any]]:
+        return {record["id"]: record for record in self.epics}
+
+
+def parse_scalar(raw: str) -> Any:
+    value = raw.strip()
+    if value in {"", "null", "None", "~"}:
+        return None
+    if value == "[]":
+        return []
+    if value.startswith('"') and value.endswith('"'):
+        return value[1:-1]
+    if value.startswith("'") and value.endswith("'"):
+        return value[1:-1]
+    if value.isdigit():
+        return int(value)
+    return value
+
+
+def load_tracker_file(path: Path) -> dict[str, Any]:
+    record: dict[str, Any] = {}
+    current_list_key: str | None = None
+    for line_number, raw_line in enumerate(
+        path.read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if raw_line.startswith("  - "):
+            if current_list_key is None:
+                raise ValueError(
+                    f"{path}:{line_number}: list item without a list field"
+                )
+            record[current_list_key].append(parse_scalar(raw_line[4:]))
+            continue
+        if raw_line.startswith(" "):
+            raise ValueError(f"{path}:{line_number}: unsupported indentation")
+        if ":" not in raw_line:
+            raise ValueError(f"{path}:{line_number}: expected 'key: value'")
+
+        key, value = raw_line.split(":", 1)
+        key = key.strip()
+        parsed = parse_scalar(value)
+        if parsed is None and not value.strip():
+            parsed = []
+            current_list_key = key
+        else:
+            current_list_key = key if isinstance(parsed, list) else None
+        record[key] = parsed
+
+    record["_path"] = path
+    return record
+
+
+def load_records(root: Path, directory: Path) -> list[dict[str, Any]]:
+    full_dir = root / directory
+    if not full_dir.exists():
+        return []
+    return [load_tracker_file(path) for path in sorted(full_dir.glob("*.yaml"))]
+
+
+def load_tracker(root: Path | None = None) -> TrackerData:
+    base = root or REPO_ROOT
+    return TrackerData(
+        root=base,
+        roadmaps=load_records(base, ROADMAPS_DIR),
+        epics=load_records(base, EPICS_DIR),
+        tasks=load_records(base, TASKS_DIR),
+    )
+
+
+def resolve_repo_path(root: Path, value: str | None) -> Path | None:
+    if not value:
+        return None
+    path = Path(value)
+    return path if path.is_absolute() else root / path
+
+
+def path_link(root: Path, view_path: Path, target: str | None) -> str:
+    if not target:
+        return "`None`"
+    resolved = resolve_repo_path(root, target)
+    if resolved is None:
+        return f"`{target}`"
+    rel = os.path.relpath(resolved, (root / view_path).parent)
+    return f"[`{target}`]({rel})"
+
+
+def validate_common(
+    root: Path, kind: str, record: dict[str, Any], errors: list[str]
+) -> None:
+    required = (
+        "id",
+        "title",
+        "status",
+        "rank",
+        "team",
+        "owner_mode",
+        "updated_at",
+        "plan_path",
+        "related_paths",
+        "linked_beads",
+        "linked_outputs",
+    )
+    label = str(record.get("_path", f"{kind}:{record.get('id', '?')}"))
+    for field in required:
+        if field not in record:
+            errors.append(f"{label}: missing required field '{field}'")
+
+    record_id = str(record.get("id", "")).strip()
+    if record_id and not SLUG_PATTERN.match(record_id):
+        errors.append(f"{label}: id must be lowercase kebab-case")
+
+    status = str(record.get("status", "")).strip()
+    if status not in STATUSES:
+        errors.append(f"{label}: invalid status '{status}'")
+
+    owner_mode = str(record.get("owner_mode", "")).strip()
+    if owner_mode not in OWNER_MODES:
+        errors.append(f"{label}: invalid owner_mode '{owner_mode}'")
+
+    team = str(record.get("team", "")).strip()
+    if team not in TEAMS:
+        errors.append(f"{label}: invalid team '{team}'")
+
+    rank = record.get("rank")
+    if not isinstance(rank, int) or rank < 1:
+        errors.append(f"{label}: rank must be a positive integer")
+
+    try:
+        date.fromisoformat(str(record.get("updated_at", "")))
+    except ValueError:
+        errors.append(f"{label}: updated_at must be YYYY-MM-DD")
+
+    plan_path = record.get("plan_path")
+    if plan_path:
+        resolved = resolve_repo_path(root, str(plan_path))
+        if resolved is None or not resolved.exists():
+            errors.append(f"{label}: plan_path does not exist: {plan_path}")
+
+    for field in ("related_paths", "linked_beads", "linked_outputs"):
+        value = record.get(field)
+        if not isinstance(value, list):
+            errors.append(f"{label}: '{field}' must be a list")
+            continue
+        for item in value:
+            resolved = resolve_repo_path(root, str(item))
+            if resolved is None or not resolved.exists():
+                errors.append(f"{label}: referenced path does not exist: {item}")
+
+
+def validate_unique_ids(
+    kind: str, records: list[dict[str, Any]], errors: list[str]
+) -> None:
+    seen: set[str] = set()
+    for record in records:
+        record_id = str(record.get("id", "")).strip()
+        if not record_id:
+            continue
+        if record_id in seen:
+            errors.append(
+                f"{record.get('_path')}: duplicate {kind[:-1]} id '{record_id}'"
+            )
+        seen.add(record_id)
+
+
+def validate_ranks(
+    records: list[dict[str, Any]], lane_label: str, errors: list[str]
+) -> None:
+    ranks: dict[int, str] = {}
+    for record in records:
+        if record.get("status") == "done":
+            continue
+        rank = record.get("rank")
+        if not isinstance(rank, int):
+            continue
+        if rank in ranks:
+            errors.append(
+                f"{record.get('_path')}: duplicate active rank {rank} in {lane_label}"
+            )
+        ranks[rank] = str(record.get("_path"))
+
+
+def validate_tracker(tracker: TrackerData) -> ValidationResult:
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    for kind in KIND_ORDER:
+        records = getattr(tracker, kind)
+        validate_unique_ids(kind, records, errors)
+        for record in records:
+            validate_common(tracker.root, kind, record, errors)
+
+    roadmap_ids = set(tracker.roadmaps_by_id)
+    epic_ids = set(tracker.epics_by_id)
+
+    epics_by_roadmap: dict[str, list[dict[str, Any]]] = {}
+    for epic in tracker.epics:
+        parent_id = str(epic.get("parent_id", "")).strip()
+        if not parent_id:
+            errors.append(f"{epic.get('_path')}: missing required field 'parent_id'")
+        elif parent_id not in roadmap_ids:
+            errors.append(
+                f"{epic.get('_path')}: parent roadmap '{parent_id}' does not exist"
+            )
+        epics_by_roadmap.setdefault(parent_id, []).append(epic)
+
+    active_tasks = []
+    tasks_by_epic: dict[str, list[dict[str, Any]]] = {}
+    for task in tracker.tasks:
+        parent_id = str(task.get("parent_id", "")).strip()
+        if not parent_id:
+            errors.append(f"{task.get('_path')}: missing required field 'parent_id'")
+        elif parent_id not in epic_ids:
+            errors.append(
+                f"{task.get('_path')}: parent epic '{parent_id}' does not exist"
+            )
+        tasks_by_epic.setdefault(parent_id, []).append(task)
+        if task.get("status") in {"active", "blocked"}:
+            active_tasks.append(task)
+            for field in ("current_task", "next_action", "resume_from"):
+                if not str(task.get(field, "")).strip():
+                    errors.append(
+                        f"{task.get('_path')}: {field} is required for active/blocked tasks"
+                    )
+
+    if (
+        len([task for task in active_tasks if task.get("status") == "active"])
+        > ACTIVE_TASK_LIMIT
+    ):
+        errors.append(
+            f"state/work/tasks: active task count exceeds limit {ACTIVE_TASK_LIMIT}"
+        )
+
+    validate_ranks(tracker.roadmaps, "roadmaps", errors)
+    for roadmap_id, epics in epics_by_roadmap.items():
+        validate_ranks(epics, f"epics/{roadmap_id}", errors)
+    for epic_id, tasks in tasks_by_epic.items():
+        validate_ranks(tasks, f"tasks/{epic_id}", errors)
+
+    if not tracker.roadmaps:
+        warnings.append("No roadmap records found")
+    if not tracker.tasks:
+        warnings.append("No task records found")
+
+    return ValidationResult(errors=errors, warnings=warnings)
+
+
+def sort_by_rank(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return sorted(
+        records,
+        key=lambda record: (
+            int(record.get("rank", 9999)),
+            STATUS_ORDER.get(str(record.get("status", "")), 99),
+            str(record.get("title", "")).lower(),
+        ),
+    )
+
+
+def task_counts(tasks: list[dict[str, Any]]) -> str:
+    counts = {status: 0 for status in STATUSES}
+    for task in tasks:
+        counts[str(task.get("status"))] = counts.get(str(task.get("status")), 0) + 1
+    ordered = ["active", "blocked", "queued", "parked", "icebox", "done"]
+    parts = [f"{counts[status]} {status}" for status in ordered if counts.get(status)]
+    return ", ".join(parts) if parts else "0 tasks"
+
+
+def build_roadmap_view(tracker: TrackerData) -> str:
+    epics_by_roadmap: dict[str, list[dict[str, Any]]] = {
+        record["id"]: [] for record in tracker.roadmaps
+    }
+    tasks_by_epic: dict[str, list[dict[str, Any]]] = {
+        record["id"]: [] for record in tracker.epics
+    }
+    for epic in tracker.epics:
+        epics_by_roadmap.setdefault(epic["parent_id"], []).append(epic)
+    for task in tracker.tasks:
+        tasks_by_epic.setdefault(task["parent_id"], []).append(task)
+
+    lines = [
+        "# CMS API Work Roadmap",
+        "",
+        "_Generated from `state/work/` by `tools/work_tracker.py`. Do not edit by hand._",
+        "",
+    ]
+    for roadmap in sort_by_rank(tracker.roadmaps):
+        lines.extend(
+            [
+                f"## [{roadmap['rank']}] {roadmap['title']}",
+                "",
+                f"- Status: `{roadmap['status']}`",
+                f"- Team: `{roadmap['team']}`",
+                f"- Owner mode: `{roadmap['owner_mode']}`",
+                f"- Updated: `{roadmap['updated_at']}`",
+                f"- Plan: {path_link(tracker.root, ROADMAP_VIEW, roadmap.get('plan_path'))}",
+            ]
+        )
+        summary = str(roadmap.get("summary", "")).strip()
+        if summary:
+            lines.append(f"- Summary: {summary}")
+        lines.extend(["", "### Epics", ""])
+
+        epics = sort_by_rank(epics_by_roadmap.get(roadmap["id"], []))
+        if not epics:
+            lines.extend(["- None.", ""])
+            continue
+
+        for epic in epics:
+            epic_tasks = sort_by_rank(tasks_by_epic.get(epic["id"], []))
+            lines.append(
+                f"- [{epic['rank']}] {epic['title']} - `{epic['status']}` "
+                f"({task_counts(epic_tasks)})"
+            )
+            lines.append(f"  Team: `{epic['team']}`")
+            lines.append(
+                f"  Plan: {path_link(tracker.root, ROADMAP_VIEW, epic.get('plan_path'))}"
+            )
+            summary = str(epic.get("summary", "")).strip()
+            if summary:
+                lines.append(f"  Summary: {summary}")
+            current = [
+                task["title"]
+                for task in epic_tasks
+                if task.get("status") in {"active", "blocked"}
+            ]
+            if current:
+                lines.append(f"  Current tasks: {', '.join(current)}")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def render_task_block(tracker: TrackerData, task: dict[str, Any]) -> list[str]:
+    epic = tracker.epics_by_id[task["parent_id"]]
+    roadmap = tracker.roadmaps_by_id[epic["parent_id"]]
+    plan_path = (
+        task.get("plan_path") or epic.get("plan_path") or roadmap.get("plan_path")
+    )
+    lines = [
+        f"### [{roadmap['rank']}.{epic['rank']}.{task['rank']}] {task['title']}",
+        "",
+        f"- Status: `{task['status']}`",
+        f"- Roadmap: `{roadmap['title']}`",
+        f"- Epic: `{epic['title']}`",
+        f"- Team: `{task['team']}`",
+        f"- Owner mode: `{task['owner_mode']}`",
+        f"- Updated: `{task['updated_at']}`",
+        f"- Plan: {path_link(tracker.root, CURRENT_VIEW, plan_path)}",
+        f"- Current task: {task.get('current_task', '') or 'None'}",
+        f"- Next action: {task.get('next_action', '') or 'None'}",
+        f"- Resume from: {task.get('resume_from', '') or 'None'}",
+    ]
+    linked_outputs = task.get("linked_outputs", []) or []
+    if linked_outputs:
+        links = ", ".join(
+            path_link(tracker.root, CURRENT_VIEW, str(path)) for path in linked_outputs
+        )
+        lines.append(f"- Linked outputs: {links}")
+    return lines + [""]
+
+
+def build_current_view(tracker: TrackerData, warnings: list[str] | None = None) -> str:
+    def task_sort_key(task: dict[str, Any]) -> tuple[int, int, int, str]:
+        epic = tracker.epics_by_id[task["parent_id"]]
+        roadmap = tracker.roadmaps_by_id[epic["parent_id"]]
+        return (
+            int(roadmap.get("rank", 9999)),
+            int(epic.get("rank", 9999)),
+            int(task.get("rank", 9999)),
+            str(task.get("title", "")).lower(),
+        )
+
+    active_tasks = sorted(
+        [task for task in tracker.tasks if task.get("status") == "active"],
+        key=task_sort_key,
+    )
+    blocked_tasks = sorted(
+        [task for task in tracker.tasks if task.get("status") == "blocked"],
+        key=task_sort_key,
+    )
+
+    lines = [
+        "# CMS API Current Work",
+        "",
+        "_Generated from `state/work/` by `tools/work_tracker.py`. Do not edit by hand._",
+        "",
+        f"- Active task WIP: **{len(active_tasks)}/{ACTIVE_TASK_LIMIT}**",
+        "",
+    ]
+    if warnings:
+        lines.extend(["## Warnings", ""])
+        lines.extend(f"- {warning}" for warning in warnings)
+        lines.append("")
+
+    lines.extend(["## Active Tasks", ""])
+    if active_tasks:
+        for task in active_tasks:
+            lines.extend(render_task_block(tracker, task))
+    else:
+        lines.extend(["- None.", ""])
+
+    lines.extend(["## Blocked Tasks", ""])
+    if blocked_tasks:
+        for task in blocked_tasks:
+            lines.extend(render_task_block(tracker, task))
+    else:
+        lines.extend(["- None.", ""])
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def write_views(tracker: TrackerData, warnings: list[str] | None = None) -> list[Path]:
+    roadmap_path = tracker.root / ROADMAP_VIEW
+    current_path = tracker.root / CURRENT_VIEW
+    roadmap_path.parent.mkdir(parents=True, exist_ok=True)
+    roadmap_path.write_text(build_roadmap_view(tracker), encoding="utf-8")
+    current_path.write_text(
+        build_current_view(tracker, warnings=warnings), encoding="utf-8"
+    )
+    return [roadmap_path, current_path]
+
+
+def check_command(root: Path) -> int:
+    tracker = load_tracker(root)
+    result = validate_tracker(tracker)
+    for error in result.errors:
+        print(f"ERROR: {error}", file=sys.stderr)
+    for warning in result.warnings:
+        print(f"WARN: {warning}")
+    if result.errors:
+        return 1
+    print("Work tracker is valid.")
+    return 0
+
+
+def build_command(root: Path) -> int:
+    tracker = load_tracker(root)
+    result = validate_tracker(tracker)
+    if result.errors:
+        for error in result.errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    written = write_views(tracker, warnings=result.warnings)
+    for path in written:
+        print(f"Wrote {path.relative_to(root)}")
+    for warning in result.warnings:
+        print(f"WARN: {warning}")
+    return 0
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "command",
+        choices=("check", "build"),
+        help="Validate tracker state or rebuild generated views.",
+    )
+    parser.add_argument("--root", type=Path, default=REPO_ROOT)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    root = args.root.resolve()
+    if args.command == "check":
+        return check_command(root)
+    if args.command == "build":
+        return build_command(root)
+    raise AssertionError(args.command)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/work_tracker.py
+++ b/tools/work_tracker.py
@@ -20,17 +20,26 @@ TASKS_DIR = STATE_DIR / "tasks"
 ROADMAP_VIEW = Path("docs/workbench/ROADMAP.md")
 CURRENT_VIEW = Path("docs/workbench/CURRENT.md")
 
-STATUSES = {"queued", "active", "blocked", "parked", "icebox", "done"}
+STATUSES = {
+    "queued",
+    "active",
+    "blocked",
+    "queued_for_merge",
+    "parked",
+    "icebox",
+    "done",
+}
 OWNER_MODES = {"alex", "agent", "shared"}
 TEAMS = {"system", "data", "api", "ops", "shared"}
 ACTIVE_TASK_LIMIT = 3
 STATUS_ORDER = {
     "active": 0,
     "blocked": 1,
-    "queued": 2,
-    "parked": 3,
-    "icebox": 4,
-    "done": 5,
+    "queued_for_merge": 2,
+    "queued": 3,
+    "parked": 4,
+    "icebox": 5,
+    "done": 6,
 }
 KIND_ORDER = ("roadmaps", "epics", "tasks")
 SLUG_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
@@ -272,12 +281,12 @@ def validate_tracker(tracker: TrackerData) -> ValidationResult:
                 f"{task.get('_path')}: parent epic '{parent_id}' does not exist"
             )
         tasks_by_epic.setdefault(parent_id, []).append(task)
-        if task.get("status") in {"active", "blocked"}:
+        if task.get("status") in {"active", "blocked", "queued_for_merge"}:
             active_tasks.append(task)
             for field in ("current_task", "next_action", "resume_from"):
                 if not str(task.get(field, "")).strip():
                     errors.append(
-                        f"{task.get('_path')}: {field} is required for active/blocked tasks"
+                        f"{task.get('_path')}: {field} is required for active/blocked/queued_for_merge tasks"
                     )
 
     if (
@@ -317,7 +326,15 @@ def task_counts(tasks: list[dict[str, Any]]) -> str:
     counts = {status: 0 for status in STATUSES}
     for task in tasks:
         counts[str(task.get("status"))] = counts.get(str(task.get("status")), 0) + 1
-    ordered = ["active", "blocked", "queued", "parked", "icebox", "done"]
+    ordered = [
+        "active",
+        "blocked",
+        "queued_for_merge",
+        "queued",
+        "parked",
+        "icebox",
+        "done",
+    ]
     parts = [f"{counts[status]} {status}" for status in ordered if counts.get(status)]
     return ", ".join(parts) if parts else "0 tasks"
 
@@ -378,7 +395,7 @@ def build_roadmap_view(tracker: TrackerData) -> str:
             current = [
                 task["title"]
                 for task in epic_tasks
-                if task.get("status") in {"active", "blocked"}
+                if task.get("status") in {"active", "blocked", "queued_for_merge"}
             ]
             if current:
                 lines.append(f"  Current tasks: {', '.join(current)}")
@@ -435,6 +452,10 @@ def build_current_view(tracker: TrackerData, warnings: list[str] | None = None) 
         [task for task in tracker.tasks if task.get("status") == "blocked"],
         key=task_sort_key,
     )
+    queued_for_merge_tasks = sorted(
+        [task for task in tracker.tasks if task.get("status") == "queued_for_merge"],
+        key=task_sort_key,
+    )
 
     lines = [
         "# CMS API Current Work",
@@ -463,6 +484,13 @@ def build_current_view(tracker: TrackerData, warnings: list[str] | None = None) 
     else:
         lines.extend(["- None.", ""])
 
+    lines.extend(["## Queued For Merge", ""])
+    if queued_for_merge_tasks:
+        for task in queued_for_merge_tasks:
+            lines.extend(render_task_block(tracker, task))
+    else:
+        lines.extend(["- None.", ""])
+
     return "\n".join(lines).rstrip() + "\n"
 
 
@@ -475,6 +503,37 @@ def write_views(tracker: TrackerData, warnings: list[str] | None = None) -> list
         build_current_view(tracker, warnings=warnings), encoding="utf-8"
     )
     return [roadmap_path, current_path]
+
+
+def check_views_command(root: Path) -> int:
+    tracker = load_tracker(root)
+    result = validate_tracker(tracker)
+    if result.errors:
+        for error in result.errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    expected = {
+        ROADMAP_VIEW: build_roadmap_view(tracker),
+        CURRENT_VIEW: build_current_view(tracker, warnings=result.warnings),
+    }
+    drifted: list[Path] = []
+    for rel_path, expected_text in expected.items():
+        path = root / rel_path
+        actual_text = path.read_text(encoding="utf-8") if path.exists() else None
+        if actual_text != expected_text:
+            drifted.append(rel_path)
+
+    if drifted:
+        for rel_path in drifted:
+            print(
+                f"ERROR: generated tracker view is stale: {rel_path}", file=sys.stderr
+            )
+        print("Run: python scripts/governance/build-work-tracker.py", file=sys.stderr)
+        return 1
+
+    print("Generated tracker views are current.")
+    return 0
 
 
 def check_command(root: Path) -> int:
@@ -509,7 +568,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "command",
-        choices=("check", "build"),
+        choices=("check", "build", "check-views"),
         help="Validate tracker state or rebuild generated views.",
     )
     parser.add_argument("--root", type=Path, default=REPO_ROOT)
@@ -523,6 +582,8 @@ def main(argv: list[str] | None = None) -> int:
         return check_command(root)
     if args.command == "build":
         return build_command(root)
+    if args.command == "check-views":
+        return check_views_command(root)
     raise AssertionError(args.command)
 
 


### PR DESCRIPTION
## Summary
- Add the CMS API work tracker state, generated views, and status doc for the RVU local DB load.
- Codify the EOD tracker sync rule: code PRs avoid tracker state and generated tracker views; tracker truth is reconciled in tracker-only sync PRs.
- Add governance commands for check, build, merge queue dry run, and generated-view drift checks.

## Validation
- .venv/bin/python scripts/governance/check-work-tracker.py
- .venv/bin/python scripts/governance/process_merge_queue.py --dry-run --json
- .venv/bin/python tools/work_tracker.py check-views
- .venv/bin/pytest tests/tools/test_work_tracker.py -q
- .venv/bin/black --check tools/work_tracker.py tests/tools/test_work_tracker.py scripts/governance/check-work-tracker.py scripts/governance/build-work-tracker.py scripts/governance/process_merge_queue.py
- git diff --check codex/rvu-release-effective-dates...HEAD

## Notes
- This PR is intentionally based on the RVU release/effective-dates branch so its diff is tracker-only while that code PR is still open. After the RVU PR merges, this tracker sync can be merged or retargeted as appropriate.