### PR TITLE
[codex] Wire RVU snapshots into MPFS pricing

### DIFF
--- a/cms_pricing/engines/mpfs.py
+++ b/cms_pricing/engines/mpfs.py
@@ -1,5 +1,7 @@
 """Medicare Physician Fee Schedule pricing engine"""
 
+from datetime import date
+from decimal import Decimal, ROUND_HALF_UP
 from typing import Any, List, Optional, Tuple
 from sqlalchemy.orm import Session
 from sqlalchemy import and_, or_
@@ -7,8 +9,11 @@ from sqlalchemy import and_, or_
 from cms_pricing.engines.base import BasePricingEngine
 from cms_pricing.database import SessionLocal
 from cms_pricing.models.fee_schedules import FeeMPFS, GPCI, ConversionFactor
+from cms_pricing.models.dataset_snapshots import DatasetSnapshot
+from cms_pricing.models.rvu import GPCIIndex, Release, RVUItem
 from cms_pricing.schemas.geography import GeographyResolveResponse
 from cms_pricing.schemas.pricing import CodePricingItem
+from cms_pricing.services.dataset_snapshot_service import DatasetSnapshotService
 import structlog
 
 logger = structlog.get_logger()
@@ -19,18 +24,18 @@ DATASET_ID = "MPFS"
 
 class MPSFEngine(BasePricingEngine):
     """Medicare Physician Fee Schedule pricing engine"""
-    
+
     def __init__(self, db: Optional[Session] = None):
         """
         Initialize MPFS engine with optional database session.
-        
+
         Args:
             db: Optional SQLAlchemy session. If None, creates a new session.
                 Session will be closed when engine is destroyed.
         """
         self.db = db if db is not None else SessionLocal()
         self._owns_session = db is None
-    
+
     @staticmethod
     def _build_mpfs_filter(year: int, code: str):
         """Build reusable filter expression for MPFS queries"""
@@ -39,11 +44,10 @@ class MPSFEngine(BasePricingEngine):
             FeeMPFS.hcpcs == code,
             FeeMPFS.effective_from <= f"{year}-12-31",
             or_(
-                FeeMPFS.effective_to.is_(None),
-                FeeMPFS.effective_to >= f"{year}-01-01"
-            )
+                FeeMPFS.effective_to.is_(None), FeeMPFS.effective_to >= f"{year}-01-01"
+            ),
         )
-    
+
     async def price_code(
         self,
         code: str,
@@ -60,74 +64,101 @@ class MPSFEngine(BasePricingEngine):
         facility_component: bool = True,
         modifiers: Optional[List[str]] = None,
         pos: Optional[str] = None,
-        ndc11: Optional[str] = None
+        ndc11: Optional[str] = None,
+        valuation_date: Optional[date] = None,
     ) -> CodePricingItem:
         """Price a code using MPFS (Quick Win #2: Returns unified CodePricingItem)"""
 
         locality_id = None
         try:
+            selected_valuation_date = self._valuation_date_from_inputs(
+                year=year,
+                quarter=quarter,
+                valuation_date=valuation_date,
+            )
+
             # Get locality from geography
             if geography and geography.selected_candidate:
                 locality_id = geography.selected_candidate.locality_id
-            
+
             if not locality_id:
                 raise ValueError("No locality found for ZIP code")
-            
+
+            rvu_result = await self._price_code_from_rvu_snapshots(
+                code=code,
+                locality_id=locality_id,
+                year=year,
+                valuation_date=selected_valuation_date,
+                geography=geography,
+                units=units,
+                utilization_weight=utilization_weight,
+                professional_component=professional_component,
+                facility_component=facility_component,
+                modifiers=modifiers,
+                pos=pos,
+            )
+            if rvu_result is not None:
+                return rvu_result
+
             # Pre-compute trace ref base (optimization)
             trace_refs = [
                 f"mpfs_{year}_{locality_id}_{code}",
                 f"gpci_{year}_{locality_id}",
-                f"cf_{year}_MPFS"
+                f"cf_{year}_MPFS",
             ]
             dataset_id = DATASET_ID
-            
+
             # Query only necessary columns using with_entities (optimization)
-            mpfs_result = self.db.query(
-                FeeMPFS.work_rvu,
-                FeeMPFS.pe_nf_rvu,
-                FeeMPFS.pe_fac_rvu,
-                FeeMPFS.mp_rvu,
-                FeeMPFS.release_id,
-                FeeMPFS.batch_id
-            ).filter(
-                self._build_mpfs_filter(year, code)
-            ).first()
-            
+            mpfs_result = (
+                self.db.query(
+                    FeeMPFS.work_rvu,
+                    FeeMPFS.pe_nf_rvu,
+                    FeeMPFS.pe_fac_rvu,
+                    FeeMPFS.mp_rvu,
+                    FeeMPFS.release_id,
+                    FeeMPFS.batch_id,
+                )
+                .filter(self._build_mpfs_filter(year, code))
+                .first()
+            )
+
             if not mpfs_result:
                 raise ValueError(f"No MPFS data found for code {code} for year {year}")
-            
+
             # Query GPCI with column selection
-            gpci_result = self.db.query(
-                GPCI.gpci_work,
-                GPCI.gpci_pe,
-                GPCI.gpci_mp,
-                GPCI.release_id,
-                GPCI.batch_id
-            ).filter(
-                and_(
-                    GPCI.year == year,
-                    GPCI.locality_id == locality_id
+            gpci_result = (
+                self.db.query(
+                    GPCI.gpci_work,
+                    GPCI.gpci_pe,
+                    GPCI.gpci_mp,
+                    GPCI.release_id,
+                    GPCI.batch_id,
                 )
-            ).first()
-            
+                .filter(and_(GPCI.year == year, GPCI.locality_id == locality_id))
+                .first()
+            )
+
             if not gpci_result:
                 raise ValueError(f"No GPCI data found for locality {locality_id}")
-            
+
             # Query conversion factor with column selection
-            cf_result = self.db.query(
-                ConversionFactor.cf,
-                ConversionFactor.release_id,
-                ConversionFactor.batch_id
-            ).filter(
-                and_(
-                    ConversionFactor.year == year,
-                    ConversionFactor.source == "MPFS"
+            cf_result = (
+                self.db.query(
+                    ConversionFactor.cf,
+                    ConversionFactor.release_id,
+                    ConversionFactor.batch_id,
                 )
-            ).first()
-            
+                .filter(
+                    and_(
+                        ConversionFactor.year == year, ConversionFactor.source == "MPFS"
+                    )
+                )
+                .first()
+            )
+
             if not cf_result:
                 raise ValueError(f"No conversion factor found for year {year}")
-            
+
             required_values = {
                 "work_rvu": mpfs_result.work_rvu,
                 "mp_rvu": mpfs_result.mp_rvu,
@@ -136,7 +167,9 @@ class MPSFEngine(BasePricingEngine):
                 "gpci_mp": gpci_result.gpci_mp,
                 "conversion_factor": cf_result.cf,
             }
-            missing_values = [name for name, value in required_values.items() if value is None]
+            missing_values = [
+                name for name, value in required_values.items() if value is None
+            ]
             if missing_values:
                 raise ValueError(
                     f"Missing MPFS pricing inputs for code {code}, locality {locality_id}: "
@@ -150,23 +183,23 @@ class MPSFEngine(BasePricingEngine):
             mp_rvu = mpfs_result.mp_rvu
             mpfs_release_id = mpfs_result.release_id
             mpfs_batch_id = mpfs_result.batch_id
-            
+
             gpci_work = gpci_result.gpci_work
             gpci_pe = gpci_result.gpci_pe
             gpci_mp = gpci_result.gpci_mp
             gpci_release_id = gpci_result.release_id
             gpci_batch_id = gpci_result.batch_id
-            
+
             cf = cf_result.cf
             cf_release_id = cf_result.release_id
             cf_batch_id = cf_result.batch_id
-            
+
             # Determine PE RVU based on POS (need to create a minimal object for _get_pe_rvu)
             class MPFSData:
                 def __init__(self):
                     self.pe_nf_rvu = pe_nf_rvu
                     self.pe_fac_rvu = pe_fac_rvu
-            
+
             mpfs_data_obj = MPFSData()
             pe_rvu = self._get_pe_rvu(mpfs_data_obj, pos)
 
@@ -174,12 +207,12 @@ class MPSFEngine(BasePricingEngine):
                 raise ValueError(
                     f"Missing PE RVU for code {code}, locality {locality_id}, POS {pos or 'default'}"
                 )
-            
+
             # Apply GPCI
             work_rvu_adjusted = work_rvu * gpci_work
             pe_rvu_adjusted = pe_rvu * gpci_pe
             mp_rvu_adjusted = mp_rvu * gpci_mp
-            
+
             professional_base, technical_base = self._select_component_amounts(
                 work_rvu_adjusted=work_rvu_adjusted,
                 pe_rvu_adjusted=pe_rvu_adjusted,
@@ -194,42 +227,56 @@ class MPSFEngine(BasePricingEngine):
             professional_allowed_amount = professional_base * quantity_multiplier
             technical_allowed_amount = technical_base * quantity_multiplier
             allowed_amount = professional_allowed_amount + technical_allowed_amount
-            
+
             # Calculate beneficiary cost sharing
             cost_sharing = self._calculate_beneficiary_cost_sharing(allowed_amount)
-            
+
             # Convert to cents
             allowed_cents = self._amount_to_cents(allowed_amount)
-            beneficiary_deductible_cents = self._amount_to_cents(cost_sharing["beneficiary_deductible"])
-            beneficiary_coinsurance_cents = self._amount_to_cents(cost_sharing["beneficiary_coinsurance"])
-            beneficiary_total_cents = self._amount_to_cents(cost_sharing["beneficiary_total"])
-            program_payment_cents = self._amount_to_cents(cost_sharing["program_payment"])
-            professional_allowed_cents = self._amount_to_cents(professional_allowed_amount)
+            beneficiary_deductible_cents = self._amount_to_cents(
+                cost_sharing["beneficiary_deductible"]
+            )
+            beneficiary_coinsurance_cents = self._amount_to_cents(
+                cost_sharing["beneficiary_coinsurance"]
+            )
+            beneficiary_total_cents = self._amount_to_cents(
+                cost_sharing["beneficiary_total"]
+            )
+            program_payment_cents = self._amount_to_cents(
+                cost_sharing["program_payment"]
+            )
+            professional_allowed_cents = self._amount_to_cents(
+                professional_allowed_amount
+            )
             technical_allowed_cents = self._amount_to_cents(technical_allowed_amount)
-            
+
             # Add MPFS provenance (standardized format)
             if mpfs_release_id:
                 trace_refs.append(f"{dataset_id}:release:{mpfs_release_id}")
             if mpfs_batch_id:
                 trace_refs.append(f"{dataset_id}:batch:{mpfs_batch_id}")
-            
+
             # Add supporting data provenance if available
             if gpci_release_id:
                 trace_refs.append(f"GPCI:release:{gpci_release_id}")
             if gpci_batch_id:
                 trace_refs.append(f"GPCI:batch:{gpci_batch_id}")
-            
+
             if cf_release_id:
                 trace_refs.append(f"CF:release:{cf_release_id}")
             if cf_batch_id:
                 trace_refs.append(f"CF:batch:{cf_batch_id}")
-            
+
             # Filter out None values and deduplicate while preserving order
-            trace_refs = list(dict.fromkeys([ref for ref in trace_refs if ref is not None]))
-            
+            trace_refs = list(
+                dict.fromkeys([ref for ref in trace_refs if ref is not None])
+            )
+
             # Extract primary modifier (if multiple, use first)
-            primary_modifier = modifiers[0] if modifiers and len(modifiers) > 0 else None
-            
+            primary_modifier = (
+                modifiers[0] if modifiers and len(modifiers) > 0 else None
+            )
+
             return CodePricingItem(
                 code=code,
                 setting="MPFS",
@@ -248,9 +295,9 @@ class MPSFEngine(BasePricingEngine):
                 source="benchmark",
                 facility_specific=False,
                 packaged=False,
-                units=units
+                units=units,
             )
-            
+
         except Exception as e:
             logger.error(
                 "MPFS pricing failed",
@@ -259,17 +306,459 @@ class MPSFEngine(BasePricingEngine):
                 year=year,
                 locality_id=locality_id,
                 error=str(e),
-                exc_info=True
+                exc_info=True,
             )
             raise
-    
+
+    @staticmethod
+    def _valuation_date_from_inputs(
+        *,
+        year: int,
+        quarter: Optional[str],
+        valuation_date: Optional[date],
+    ) -> date:
+        if valuation_date is not None:
+            return valuation_date
+
+        if quarter:
+            quarter_starts = {
+                "1": (1, 1),
+                "2": (4, 1),
+                "3": (7, 1),
+                "4": (10, 1),
+            }
+            month, day = quarter_starts[str(quarter)]
+            return date(year, month, day)
+
+        return date(year, 12, 31)
+
+    async def _price_code_from_rvu_snapshots(
+        self,
+        *,
+        code: str,
+        locality_id: str,
+        year: int,
+        valuation_date: date,
+        geography: Optional[GeographyResolveResponse],
+        units: float,
+        utilization_weight: float,
+        professional_component: bool,
+        facility_component: bool,
+        modifiers: Optional[List[str]],
+        pos: Optional[str],
+    ) -> Optional[CodePricingItem]:
+        snapshots = self._select_rvu_pricing_snapshots(valuation_date)
+        if snapshots is None:
+            return None
+
+        rvu_snapshot, gpci_snapshot = snapshots
+        if not self._snapshot_release_keys_match(rvu_snapshot, gpci_snapshot):
+            raise ValueError(
+                "Selected RVU and GPCI snapshots do not describe the same CMS release: "
+                f"{rvu_snapshot.release_id} vs {gpci_snapshot.release_id}"
+            )
+
+        release = self._release_for_rvu_snapshot(rvu_snapshot)
+        if release is None:
+            raise ValueError(
+                f"No RVU database release found for selected snapshot {rvu_snapshot.release_id}"
+            )
+
+        rvu_row = self._query_rvu_item(release.id, code)
+        if rvu_row is None:
+            raise ValueError(
+                f"No RVU data found for code {code} in selected snapshot {rvu_snapshot.release_id}"
+            )
+
+        gpci_row = self._query_gpci_index(
+            release_id=release.id,
+            locality_id=locality_id,
+            geography=geography,
+        )
+        if gpci_row is None:
+            raise ValueError(
+                f"No GPCI data found for locality {locality_id} in selected snapshot {gpci_snapshot.release_id}"
+            )
+
+        work_rvu = self._required_decimal(
+            rvu_row.work_rvu, "work_rvu", code, locality_id
+        )
+        pe_nf_rvu = self._optional_decimal(rvu_row.pe_rvu_nonfac)
+        pe_fac_rvu = self._optional_decimal(rvu_row.pe_rvu_fac)
+        mp_rvu = self._required_decimal(rvu_row.mp_rvu, "mp_rvu", code, locality_id)
+        conversion_factor = self._required_decimal(
+            rvu_row.conversion_factor,
+            "conversion_factor",
+            code,
+            locality_id,
+        )
+
+        gpci_work = self._required_decimal(
+            gpci_row.work_gpci, "work_gpci", code, locality_id
+        )
+        gpci_pe = self._required_decimal(gpci_row.pe_gpci, "pe_gpci", code, locality_id)
+        gpci_mp = self._required_decimal(gpci_row.mp_gpci, "mp_gpci", code, locality_id)
+
+        pe_rvu = self._select_pe_rvu_decimal(
+            pe_nonfac_rvu=pe_nf_rvu,
+            pe_fac_rvu=pe_fac_rvu,
+            pos=pos,
+            code=code,
+            locality_id=locality_id,
+        )
+
+        work_rvu_adjusted = work_rvu * gpci_work
+        pe_rvu_adjusted = pe_rvu * gpci_pe
+        mp_rvu_adjusted = mp_rvu * gpci_mp
+
+        professional_base, technical_base = self._select_component_amounts_decimal(
+            work_rvu_adjusted=work_rvu_adjusted,
+            pe_rvu_adjusted=pe_rvu_adjusted,
+            mp_rvu_adjusted=mp_rvu_adjusted,
+            conversion_factor=conversion_factor,
+            professional_component=professional_component,
+            facility_component=facility_component,
+            modifiers=modifiers,
+        )
+
+        quantity_multiplier = Decimal(str(units)) * Decimal(str(utilization_weight))
+        professional_allowed_amount = professional_base * quantity_multiplier
+        technical_allowed_amount = technical_base * quantity_multiplier
+        allowed_amount = professional_allowed_amount + technical_allowed_amount
+        cost_sharing = self._calculate_beneficiary_cost_sharing_decimal(allowed_amount)
+
+        primary_modifier = modifiers[0] if modifiers and len(modifiers) > 0 else None
+        trace_refs = list(
+            dict.fromkeys(
+                [
+                    f"mpfs_rvu_{valuation_date.isoformat()}_{locality_id}_{code}",
+                    f"rvu_{rvu_snapshot.release_id}_{code}",
+                    f"gpci_{gpci_snapshot.release_id}_{locality_id}",
+                    f"cf_{rvu_snapshot.release_id}_rvu_items",
+                    f"{DATASET_ID}:release:{rvu_snapshot.release_id}",
+                    f"RVU:release:{rvu_snapshot.release_id}",
+                    f"GPCI:release:{gpci_snapshot.release_id}",
+                    f"CF:release:{rvu_snapshot.release_id}",
+                    "CF:source:rvu_items.conversion_factor",
+                ]
+            )
+        )
+
+        batch_id = str(release.notes) if release.notes else None
+        if batch_id:
+            trace_refs.append(f"{DATASET_ID}:batch:{batch_id}")
+
+        return CodePricingItem(
+            code=code,
+            setting="MPFS",
+            modifier=primary_modifier,
+            allowed_cents=self._decimal_to_cents(allowed_amount),
+            beneficiary_deductible_cents=self._decimal_to_cents(
+                cost_sharing["beneficiary_deductible"]
+            ),
+            beneficiary_coinsurance_cents=self._decimal_to_cents(
+                cost_sharing["beneficiary_coinsurance"]
+            ),
+            beneficiary_total_cents=self._decimal_to_cents(
+                cost_sharing["beneficiary_total"]
+            ),
+            program_payment_cents=self._decimal_to_cents(
+                cost_sharing["program_payment"]
+            ),
+            professional_allowed_cents=self._decimal_to_cents(
+                professional_allowed_amount
+            ),
+            facility_allowed_cents=self._decimal_to_cents(technical_allowed_amount),
+            dataset_id=DATASET_ID,
+            release_id=rvu_snapshot.release_id,
+            batch_id=batch_id,
+            trace_refs=trace_refs,
+            source="benchmark",
+            facility_specific=False,
+            packaged=False,
+            units=units,
+        )
+
+    def _select_rvu_pricing_snapshots(
+        self,
+        valuation_date: date,
+    ) -> Optional[Tuple[DatasetSnapshot, DatasetSnapshot]]:
+        if not isinstance(self.db, Session):
+            return None
+
+        snapshot_service = DatasetSnapshotService(self.db)
+        rvu_snapshot = snapshot_service.select_snapshot(
+            "rvu_items",
+            valuation_date=valuation_date,
+        )
+        gpci_snapshot = snapshot_service.select_snapshot(
+            "gpci_indices",
+            valuation_date=valuation_date,
+        )
+
+        if rvu_snapshot is None and gpci_snapshot is None:
+            return None
+        if rvu_snapshot is None or gpci_snapshot is None:
+            raise ValueError(
+                "Partial RVU pricing snapshot state: both rvu_items and gpci_indices "
+                f"must be registered for {valuation_date.isoformat()}"
+            )
+        if not isinstance(rvu_snapshot, DatasetSnapshot) or not isinstance(
+            gpci_snapshot, DatasetSnapshot
+        ):
+            return None
+        return rvu_snapshot, gpci_snapshot
+
+    @staticmethod
+    def _snapshot_release_key(snapshot: DatasetSnapshot) -> Optional[str]:
+        parts = str(snapshot.release_id or "").split("_", 1)
+        if len(parts) != 2:
+            return None
+        return parts[1]
+
+    @classmethod
+    def _snapshot_release_keys_match(
+        cls,
+        rvu_snapshot: DatasetSnapshot,
+        gpci_snapshot: DatasetSnapshot,
+    ) -> bool:
+        rvu_key = cls._snapshot_release_key(rvu_snapshot)
+        gpci_key = cls._snapshot_release_key(gpci_snapshot)
+        return bool(rvu_key and gpci_key and rvu_key == gpci_key)
+
+    def _release_for_rvu_snapshot(self, snapshot: DatasetSnapshot) -> Optional[Release]:
+        source_version = str(snapshot.release_id or "")[:10]
+        if not source_version:
+            return None
+        return (
+            self.db.query(Release)
+            .filter(
+                Release.type == "RVU_FULL",
+                Release.source_version == source_version,
+            )
+            .order_by(Release.imported_at.desc())
+            .first()
+        )
+
+    def _query_rvu_item(self, release_id: Any, code: str) -> Optional[Any]:
+        return (
+            self.db.query(
+                RVUItem.work_rvu,
+                RVUItem.pe_rvu_nonfac,
+                RVUItem.pe_rvu_fac,
+                RVUItem.mp_rvu,
+                RVUItem.conversion_factor,
+            )
+            .filter(
+                RVUItem.release_id == release_id,
+                RVUItem.hcpcs_code == code,
+                or_(RVUItem.modifier_key.is_(None), RVUItem.modifier_key == ""),
+            )
+            .first()
+        )
+
+    def _query_gpci_index(
+        self,
+        *,
+        release_id: Any,
+        locality_id: str,
+        geography: Optional[GeographyResolveResponse],
+    ) -> Optional[Any]:
+        locality_candidates = self._locality_candidates(locality_id)
+        state_code = None
+        if geography and geography.selected_candidate:
+            state_code = geography.selected_candidate.state_code
+
+        query = self.db.query(
+            GPCIIndex.work_gpci,
+            GPCIIndex.pe_gpci,
+            GPCIIndex.mp_gpci,
+        ).filter(
+            GPCIIndex.release_id == release_id,
+            GPCIIndex.locality_id.in_(locality_candidates),
+        )
+        if state_code:
+            query = query.filter(GPCIIndex.state == state_code)
+
+        row = query.order_by(GPCIIndex.locality_id.asc()).first()
+        if row or not state_code:
+            return row
+
+        return (
+            self.db.query(
+                GPCIIndex.work_gpci,
+                GPCIIndex.pe_gpci,
+                GPCIIndex.mp_gpci,
+            )
+            .filter(
+                GPCIIndex.release_id == release_id,
+                GPCIIndex.locality_id.in_(locality_candidates),
+            )
+            .order_by(GPCIIndex.locality_id.asc())
+            .first()
+        )
+
+    @staticmethod
+    def _locality_candidates(locality_id: str) -> List[str]:
+        raw = str(locality_id or "").strip()
+        candidates = [raw]
+        if raw.isdigit():
+            candidates.append(raw.zfill(2))
+        return list(dict.fromkeys(candidate for candidate in candidates if candidate))
+
+    @staticmethod
+    def _optional_decimal(value: Any) -> Optional[Decimal]:
+        if value is None:
+            return None
+        return Decimal(str(value))
+
+    @classmethod
+    def _required_decimal(
+        cls,
+        value: Any,
+        field_name: str,
+        code: str,
+        locality_id: str,
+    ) -> Decimal:
+        converted = cls._optional_decimal(value)
+        if converted is None:
+            raise ValueError(
+                f"Missing MPFS pricing input {field_name} for code {code}, locality {locality_id}"
+            )
+        return converted
+
+    @staticmethod
+    def _select_pe_rvu_decimal(
+        *,
+        pe_nonfac_rvu: Optional[Decimal],
+        pe_fac_rvu: Optional[Decimal],
+        pos: Optional[str],
+        code: str,
+        locality_id: str,
+    ) -> Decimal:
+        use_nonfacility = bool(
+            pos
+            and pos
+            in ["11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21"]
+        )
+        selected = pe_nonfac_rvu if use_nonfacility else pe_fac_rvu
+        if selected is None:
+            setting = "non-facility" if use_nonfacility else "facility"
+            raise ValueError(
+                f"Missing {setting} PE RVU for code {code}, locality {locality_id}, POS {pos or 'default'}"
+            )
+        return selected
+
+    def _select_component_amounts_decimal(
+        self,
+        *,
+        work_rvu_adjusted: Decimal,
+        pe_rvu_adjusted: Decimal,
+        mp_rvu_adjusted: Decimal,
+        conversion_factor: Decimal,
+        professional_component: bool,
+        facility_component: bool,
+        modifiers: Optional[List[str]],
+    ) -> Tuple[Decimal, Decimal]:
+        modifier_codes = [
+            self._normalize_modifier_code(modifier)
+            for modifier in modifiers or []
+            if str(modifier).strip()
+        ]
+        has_professional_modifier = "26" in modifier_codes
+        has_technical_modifier = "TC" in modifier_codes
+
+        if has_professional_modifier and has_technical_modifier:
+            raise ValueError("MPFS modifiers 26 and TC cannot both be applied")
+
+        if has_professional_modifier:
+            include_professional = True
+            include_technical = False
+        elif has_technical_modifier:
+            include_professional = False
+            include_technical = True
+        else:
+            include_professional = professional_component
+            include_technical = facility_component
+
+        if not include_professional and not include_technical:
+            raise ValueError("At least one MPFS component must be selected")
+
+        generic_modifiers = [
+            modifier
+            for modifier in modifiers or []
+            if self._normalize_modifier_code(modifier) not in {"26", "TC"}
+        ]
+
+        professional_amount = (work_rvu_adjusted + mp_rvu_adjusted) * conversion_factor
+        technical_amount = pe_rvu_adjusted * conversion_factor
+
+        if include_professional:
+            professional_amount = self._apply_modifiers_decimal(
+                professional_amount,
+                generic_modifiers,
+            )
+        else:
+            professional_amount = Decimal("0")
+
+        if include_technical:
+            technical_amount = self._apply_modifiers_decimal(
+                technical_amount,
+                generic_modifiers,
+            )
+        else:
+            technical_amount = Decimal("0")
+
+        return professional_amount, technical_amount
+
+    def _apply_modifiers_decimal(
+        self,
+        base_amount: Decimal,
+        modifiers: List[str],
+    ) -> Decimal:
+        amount = base_amount
+        for modifier in modifiers:
+            modifier_code = self._normalize_modifier_code(modifier)
+            if modifier_code == "50":
+                amount *= Decimal("1.5")
+            elif modifier_code == "51":
+                amount *= Decimal("0.5")
+        return amount
+
+    @staticmethod
+    def _calculate_beneficiary_cost_sharing_decimal(
+        allowed_amount: Decimal,
+        deductible_remaining: Decimal = Decimal("0"),
+        coinsurance_rate: Decimal = Decimal("0.20"),
+    ) -> dict[str, Decimal]:
+        deductible_applied = min(deductible_remaining, allowed_amount)
+        remaining_after_deductible = allowed_amount - deductible_applied
+        coinsurance = remaining_after_deductible * coinsurance_rate
+        beneficiary_total = deductible_applied + coinsurance
+        program_payment = allowed_amount - beneficiary_total
+        return {
+            "beneficiary_deductible": deductible_applied,
+            "beneficiary_coinsurance": coinsurance,
+            "beneficiary_total": beneficiary_total,
+            "program_payment": program_payment,
+        }
+
+    @staticmethod
+    def _decimal_to_cents(amount: Decimal) -> int:
+        return int(
+            (amount * Decimal("100")).quantize(
+                Decimal("1"),
+                rounding=ROUND_HALF_UP,
+            )
+        )
+
     def _get_pe_rvu(self, mpfs_data: Any, pos: Optional[str]) -> Optional[float]:
         """Get appropriate PE RVU based on place of service"""
-        
+
         if not pos:
             # Default to facility PE RVU
             return mpfs_data.pe_fac_rvu
-        
+
         # POS mapping logic
         if pos in ["11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21"]:
             # Office/clinic settings - use non-facility PE RVU
@@ -325,20 +814,28 @@ class MPSFEngine(BasePricingEngine):
         technical_amount = pe_rvu_adjusted * conversion_factor
 
         if include_professional:
-            professional_amount = self._apply_modifiers(professional_amount, generic_modifiers)
+            professional_amount = self._apply_modifiers(
+                professional_amount, generic_modifiers
+            )
         else:
             professional_amount = 0.0
 
         if include_technical:
-            technical_amount = self._apply_modifiers(technical_amount, generic_modifiers)
+            technical_amount = self._apply_modifiers(
+                technical_amount, generic_modifiers
+            )
         else:
             technical_amount = 0.0
 
         return professional_amount, technical_amount
-    
+
     def __del__(self):
         """Clean up database session if we own it"""
-        if hasattr(self, '_owns_session') and self._owns_session and hasattr(self, 'db'):
+        if (
+            hasattr(self, "_owns_session")
+            and self._owns_session
+            and hasattr(self, "db")
+        ):
             try:
                 self.db.close()
             except Exception:

--- a/cms_pricing/routers/pricing.py
+++ b/cms_pricing/routers/pricing.py
@@ -1,5 +1,6 @@
 """Pricing endpoints"""
 
+from datetime import date
 from typing import Optional
 from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -8,8 +9,13 @@ from slowapi.util import get_remote_address
 from sqlalchemy.orm import Session
 
 from cms_pricing.schemas.pricing import (
-    PricingRequest, PricingResponse, ComparisonRequest, ComparisonResponse,
-    CodePricingItem, CodePricingItemWithGeography, GeographyResponse
+    PricingRequest,
+    PricingResponse,
+    ComparisonRequest,
+    ComparisonResponse,
+    CodePricingItem,
+    CodePricingItemWithGeography,
+    GeographyResponse,
 )
 from cms_pricing.auth import verify_api_key
 from cms_pricing.services.pricing import PricingService
@@ -27,27 +33,29 @@ async def price_single_code(
     setting: str,
     year: int,
     quarter: Optional[str] = None,
+    valuation_date: Optional[date] = None,
     ccn: Optional[str] = None,
     payer: Optional[str] = None,
     plan: Optional[str] = None,
+    pos: Optional[str] = None,
     db: Session = Depends(get_db),
-    api_key: str = Depends(verify_api_key)
+    api_key: str = Depends(verify_api_key),
 ):
     """
     Price a single code/component.
-    
+
     **Response Format (Quick Win #2):**
     Returns CodePricingItemWithGeography, which extends CodePricingItem with geography and run_id metadata.
     The core pricing data follows CodePricingItem structure for consistency across all datasets.
-    
+
     **Response Fields:**
     - All fields from CodePricingItem (code, setting, allowed_cents, dataset_id, etc.)
     - **geography**: GeographyResponse object with ZIP resolution details (locality_id, CBSA, etc.)
     - **run_id**: Unique identifier for this pricing request
-    
+
     **Provenance Metadata (Phase 2):**
     The response includes provenance information to trace pricing results back to specific CMS data versions:
-    
+
     - **dataset_id**: Dataset identifier (MPFS, OPPS, ASC, etc.)
     - **release_id**: CMS release identifier (Phase 2 provenance, may be None for legacy data)
     - **batch_id**: Batch identifier from ingestion (Phase 2 provenance, may be None for legacy data)
@@ -55,30 +63,32 @@ async def price_single_code(
       - Format: `{dataset_id}:release:{release_id}` or `{dataset_id}:batch:{batch_id}`
       - Examples: 'MPFS:release:mpfs_2025_annual_20250115', 'OPPS:batch:batch_abc123'
       - Automatically deduplicated
-    
+
     **Backward Compatibility:**
     Legacy data (ingested before Phase 2) will have None values for release_id and batch_id.
     """
-    
+
     # Validate inputs
     if not zip.isdigit() or len(zip) != 5:
         raise HTTPException(status_code=400, detail="ZIP must be exactly 5 digits")
-    
+
     if not code or len(code) > 5:
         raise HTTPException(status_code=400, detail="Code must be 1-5 characters")
-    
-    if setting not in ['MPFS', 'OPPS', 'ASC', 'IPPS', 'CLFS', 'DMEPOS']:
+
+    if setting not in ["MPFS", "OPPS", "ASC", "IPPS", "CLFS", "DMEPOS"]:
         raise HTTPException(status_code=400, detail="Invalid setting")
-    
+
     if year < 2020 or year > 2030:
-        raise HTTPException(status_code=400, detail="Year must be between 2020 and 2030")
-    
-    if quarter and quarter not in ['1', '2', '3', '4']:
+        raise HTTPException(
+            status_code=400, detail="Year must be between 2020 and 2030"
+        )
+
+    if quarter and quarter not in ["1", "2", "3", "4"]:
         raise HTTPException(status_code=400, detail="Quarter must be 1-4")
-    
+
     if ccn and (not ccn.isdigit() or len(ccn) != 6):
         raise HTTPException(status_code=400, detail="CCN must be exactly 6 digits")
-    
+
     try:
         pricing_service = PricingService(db)
         result = await pricing_service.price_single_code(
@@ -87,16 +97,15 @@ async def price_single_code(
             setting=setting,
             year=year,
             quarter=quarter,
+            valuation_date=valuation_date,
             ccn=ccn,
             payer=payer,
-            plan=plan
+            plan=plan,
+            pos=pos,
         )
         return result
     except Exception as e:
-        raise HTTPException(
-            status_code=500,
-            detail=f"Pricing failed: {str(e)}"
-        )
+        raise HTTPException(status_code=500, detail=f"Pricing failed: {str(e)}")
 
 
 @router.post("/price", response_model=PricingResponse)
@@ -104,37 +113,34 @@ async def price_plan(
     request: Request,
     pricing_request: PricingRequest,
     db: Session = Depends(get_db),
-    api_key: str = Depends(verify_api_key)
+    api_key: str = Depends(verify_api_key),
 ):
     """
     Price a complete treatment plan.
-    
+
     **Provenance Metadata (Phase 2):**
     The response includes provenance information in two places:
-    
+
     1. **datasets_used** (response.datasets_used): List of datasets with release_id and batch_id
        - May contain None values for legacy data ingested before Phase 2
        - Enables traceability to specific CMS data versions
-    
+
     2. **trace_refs** (line_items[].trace_refs): Trace references in standardized format
        - Format: `{dataset_id}:release:{release_id}` or `{dataset_id}:batch:{batch_id}`
        - Examples: 'MPFS:release:mpfs_2025_annual_20250115', 'OPPS:batch:batch_abc123'
        - Automatically deduplicated
-    
+
     **Backward Compatibility:**
     Legacy data (ingested before Phase 2) will have None values for release_id and batch_id.
     The API structure remains consistent; consumers should handle optional provenance gracefully.
     """
-    
+
     try:
         pricing_service = PricingService(db)
         result = await pricing_service.price_plan(pricing_request)
         return result
     except Exception as e:
-        raise HTTPException(
-            status_code=500,
-            detail=f"Plan pricing failed: {str(e)}"
-        )
+        raise HTTPException(status_code=500, detail=f"Plan pricing failed: {str(e)}")
 
 
 @router.post("/compare", response_model=ComparisonResponse)
@@ -142,29 +148,26 @@ async def compare_locations(
     request: Request,
     comparison_request: ComparisonRequest,
     db: Session = Depends(get_db),
-    api_key: str = Depends(verify_api_key)
+    api_key: str = Depends(verify_api_key),
 ):
     """
     Compare pricing between two locations.
-    
+
     **Provenance Metadata (Phase 2):**
     Both location_a and location_b responses include provenance information:
-    
+
     - **datasets_used**: List of datasets with release_id and batch_id for each location
     - **trace_refs**: Trace references in standardized format (see /price endpoint documentation)
-    
+
     The parity_report validates that both locations use the same dataset snapshots.
-    
+
     **Backward Compatibility:**
     Legacy data (ingested before Phase 2) will have None values for release_id and batch_id.
     """
-    
+
     try:
         pricing_service = PricingService(db)
         result = await pricing_service.compare_locations(comparison_request)
         return result
     except Exception as e:
-        raise HTTPException(
-            status_code=500,
-            detail=f"Comparison failed: {str(e)}"
-        )
+        raise HTTPException(status_code=500, detail=f"Comparison failed: {str(e)}")

--- a/cms_pricing/schemas/pricing.py
+++ b/cms_pricing/schemas/pricing.py
@@ -10,74 +10,109 @@ from .geography import GeographyCandidate
 
 class PricingRequest(BaseModel):
     """Request schema for pricing a plan"""
+
     zip: str = Field(..., min_length=5, max_length=5, description="5-digit ZIP code")
     plan_id: Optional[UUID] = Field(None, description="Plan ID (if using stored plan)")
     year: int = Field(..., ge=2020, le=2030, description="Valuation year")
-    quarter: Optional[str] = Field(None, pattern=r'^[1-4]$', description="Quarter (1-4)")
-    ccn: Optional[str] = Field(None, max_length=6, description="CMS Certification Number")
+    quarter: Optional[str] = Field(
+        None, pattern=r"^[1-4]$", description="Quarter (1-4)"
+    )
+    valuation_date: Optional[date] = Field(
+        None,
+        description="Exact valuation date; overrides quarter for snapshot selection",
+    )
+    ccn: Optional[str] = Field(
+        None, max_length=6, description="CMS Certification Number"
+    )
     payer: Optional[str] = Field(None, description="Payer name filter")
     plan: Optional[str] = Field(None, description="Plan name filter")
     include_home_health: bool = Field(default=False, description="Include home health")
     include_snf: bool = Field(default=False, description="Include SNF")
     apply_sequestration: bool = Field(default=False, description="Apply sequestration")
-    sequestration_rate: float = Field(default=0.02, ge=0, le=0.1, description="Sequestration rate")
-    format: str = Field(default="cents", pattern=r'^(cents|decimal)$', description="Money format")
-    
+    sequestration_rate: float = Field(
+        default=0.02, ge=0, le=0.1, description="Sequestration rate"
+    )
+    format: str = Field(
+        default="cents", pattern=r"^(cents|decimal)$", description="Money format"
+    )
+
     # Ad-hoc plan (alternative to plan_id)
-    ad_hoc_plan: Optional[Dict[str, Any]] = Field(None, description="Ad-hoc plan definition")
-    
-    @field_validator('zip')
+    ad_hoc_plan: Optional[Dict[str, Any]] = Field(
+        None, description="Ad-hoc plan definition"
+    )
+
+    @field_validator("zip")
     @classmethod
     def validate_zip(cls, v):
         if not v.isdigit():
-            raise ValueError('ZIP must contain only digits')
+            raise ValueError("ZIP must contain only digits")
         return v
-    
-    @field_validator('ccn')
+
+    @field_validator("ccn")
     @classmethod
     def validate_ccn(cls, v):
         if v is not None and (not v.isdigit() or len(v) != 6):
-            raise ValueError('CCN must be exactly 6 digits')
+            raise ValueError("CCN must be exactly 6 digits")
         return v
-    
-    @field_validator('quarter')
+
+    @field_validator("quarter")
     @classmethod
     def validate_quarter(cls, v):
-        if v is not None and v not in ['1', '2', '3', '4']:
-            raise ValueError('Quarter must be 1, 2, 3, or 4')
+        if v is not None and v not in ["1", "2", "3", "4"]:
+            raise ValueError("Quarter must be 1, 2, 3, or 4")
         return v
 
 
 class CodePricingItem(BaseModel):
     """Unified pricing item response across all datasets
-    
+
     This schema provides a consistent structure for single-code pricing results
     returned by all pricing engines. It includes pricing amounts, component
     breakdowns, provenance metadata, and source information.
-    
+
     Part of Quick Win #2: Unified CodePricingItem Schema
     """
-    
+
     # Identity
     code: str = Field(..., description="HCPCS/CPT code")
-    setting: str = Field(..., description="Payment setting (MPFS, OPPS, ASC, IPPS, CLFS, DMEPOS)")
-    modifier: Optional[str] = Field(None, description="Modifier code (e.g., 25, 59, TC)")
-    
+    setting: str = Field(
+        ..., description="Payment setting (MPFS, OPPS, ASC, IPPS, CLFS, DMEPOS)"
+    )
+    modifier: Optional[str] = Field(
+        None, description="Modifier code (e.g., 25, 59, TC)"
+    )
+
     # Pricing results (all amounts in cents)
     allowed_cents: int = Field(..., description="Medicare allowed amount in cents")
-    beneficiary_deductible_cents: int = Field(..., description="Beneficiary deductible in cents")
-    beneficiary_coinsurance_cents: int = Field(..., description="Beneficiary coinsurance in cents")
-    beneficiary_total_cents: int = Field(..., description="Total beneficiary cost in cents")
+    beneficiary_deductible_cents: int = Field(
+        ..., description="Beneficiary deductible in cents"
+    )
+    beneficiary_coinsurance_cents: int = Field(
+        ..., description="Beneficiary coinsurance in cents"
+    )
+    beneficiary_total_cents: int = Field(
+        ..., description="Total beneficiary cost in cents"
+    )
     program_payment_cents: int = Field(..., description="Program payment in cents")
-    
+
     # Component breakdown
-    professional_allowed_cents: Optional[int] = Field(None, description="Professional component allowed amount in cents")
-    facility_allowed_cents: Optional[int] = Field(None, description="Facility component allowed amount in cents")
-    
+    professional_allowed_cents: Optional[int] = Field(
+        None, description="Professional component allowed amount in cents"
+    )
+    facility_allowed_cents: Optional[int] = Field(
+        None, description="Facility component allowed amount in cents"
+    )
+
     # Provenance (Phase 2)
-    dataset_id: str = Field(..., description="Dataset identifier (e.g., MPFS, OPPS, ASC)")
-    release_id: Optional[str] = Field(None, description="CMS release identifier (Phase 2 provenance)")
-    batch_id: Optional[str] = Field(None, description="Batch identifier from ingestion (Phase 2 provenance)")
+    dataset_id: str = Field(
+        ..., description="Dataset identifier (e.g., MPFS, OPPS, ASC)"
+    )
+    release_id: Optional[str] = Field(
+        None, description="CMS release identifier (Phase 2 provenance)"
+    )
+    batch_id: Optional[str] = Field(
+        None, description="Batch identifier from ingestion (Phase 2 provenance)"
+    )
     trace_refs: List[str] = Field(
         default_factory=list,
         description="""Trace reference IDs for debugging and audit purposes.
@@ -87,90 +122,127 @@ class CodePricingItem(BaseModel):
         - Provenance references (Phase 2): '{dataset_id}:release:{release_id}' or '{dataset_id}:batch:{batch_id}'
           Examples: 'MPFS:release:mpfs_2025_annual_20250115', 'MPFS:batch:batch_abc123'
         
-        Duplicates are automatically removed to keep logs clean."""
+        Duplicates are automatically removed to keep logs clean.""",
     )
-    
+
     # Source information
     source: str = Field(..., description="Data source (benchmark, mrf, tic)")
-    facility_specific: bool = Field(default=False, description="Whether facility-specific rate was used")
-    packaged: bool = Field(default=False, description="Whether item is packaged (OPPS-specific)")
-    
+    facility_specific: bool = Field(
+        default=False, description="Whether facility-specific rate was used"
+    )
+    packaged: bool = Field(
+        default=False, description="Whether item is packaged (OPPS-specific)"
+    )
+
     # Drug-specific fields (optional)
-    reference_price_cents: Optional[int] = Field(None, description="NADAC reference price in cents (drugs only)")
-    unit_conversion: Optional[Dict[str, Any]] = Field(None, description="Unit conversion details (drugs only)")
-    
+    reference_price_cents: Optional[int] = Field(
+        None, description="NADAC reference price in cents (drugs only)"
+    )
+    unit_conversion: Optional[Dict[str, Any]] = Field(
+        None, description="Unit conversion details (drugs only)"
+    )
+
     # Metadata
-    units: float = Field(default=1.0, description="Number of units (default 1.0 for single-code pricing)")
-    
+    units: float = Field(
+        default=1.0, description="Number of units (default 1.0 for single-code pricing)"
+    )
+
     @classmethod
-    def from_dict(cls, data: Dict[str, Any], setting: str, code: str, modifier: Optional[str] = None) -> "CodePricingItem":
+    def from_dict(
+        cls,
+        data: Dict[str, Any],
+        setting: str,
+        code: str,
+        modifier: Optional[str] = None,
+    ) -> "CodePricingItem":
         """Create CodePricingItem from engine result dict (backward compatibility)"""
         return cls(
             code=code,
             setting=setting,
             modifier=modifier,
-            allowed_cents=data.get('allowed_cents', 0),
-            beneficiary_deductible_cents=data.get('beneficiary_deductible_cents', 0),
-            beneficiary_coinsurance_cents=data.get('beneficiary_coinsurance_cents', 0),
-            beneficiary_total_cents=data.get('beneficiary_total_cents', 0),
-            program_payment_cents=data.get('program_payment_cents', 0),
-            professional_allowed_cents=data.get('professional_allowed_cents'),
-            facility_allowed_cents=data.get('facility_allowed_cents'),
-            dataset_id=data.get('dataset_id', setting),
-            release_id=data.get('release_id'),
-            batch_id=data.get('batch_id'),
-            trace_refs=data.get('trace_refs', []),
-            source=data.get('source', 'benchmark'),
-            facility_specific=data.get('facility_specific', False),
-            packaged=data.get('packaged', False),
-            reference_price_cents=data.get('reference_price_cents'),
-            unit_conversion=data.get('unit_conversion'),
-            units=data.get('units', 1.0)
+            allowed_cents=data.get("allowed_cents", 0),
+            beneficiary_deductible_cents=data.get("beneficiary_deductible_cents", 0),
+            beneficiary_coinsurance_cents=data.get("beneficiary_coinsurance_cents", 0),
+            beneficiary_total_cents=data.get("beneficiary_total_cents", 0),
+            program_payment_cents=data.get("program_payment_cents", 0),
+            professional_allowed_cents=data.get("professional_allowed_cents"),
+            facility_allowed_cents=data.get("facility_allowed_cents"),
+            dataset_id=data.get("dataset_id", setting),
+            release_id=data.get("release_id"),
+            batch_id=data.get("batch_id"),
+            trace_refs=data.get("trace_refs", []),
+            source=data.get("source", "benchmark"),
+            facility_specific=data.get("facility_specific", False),
+            packaged=data.get("packaged", False),
+            reference_price_cents=data.get("reference_price_cents"),
+            unit_conversion=data.get("unit_conversion"),
+            units=data.get("units", 1.0),
         )
 
 
 class CodePricingItemWithGeography(CodePricingItem):
     """CodePricingItem with geography metadata (response model for /pricing/codes/price)
-    
+
     Extends CodePricingItem to include geography resolution information and run_id
     for single-code pricing endpoint responses.
-    
+
     Part of Quick Win #2: Unified CodePricingItem Schema
     """
-    
+
     # Additional metadata for single-code endpoint
-    geography: "GeographyResponse" = Field(..., description="Geography resolution information")
-    run_id: str = Field(..., description="Unique run identifier for this pricing request")
+    geography: "GeographyResponse" = Field(
+        ..., description="Geography resolution information"
+    )
+    run_id: str = Field(
+        ..., description="Unique run identifier for this pricing request"
+    )
 
 
 class LineItemResponse(BaseModel):
     """Response schema for a pricing line item"""
+
     sequence: int = Field(..., description="Line sequence number")
     code: str = Field(..., description="HCPCS/CPT code")
     setting: str = Field(..., description="Payment setting")
     units: float = Field(..., description="Number of units")
     utilization_weight: float = Field(..., description="Utilization weight")
-    
+
     # Pricing results
     allowed_cents: int = Field(..., description="Medicare allowed amount in cents")
-    beneficiary_deductible_cents: int = Field(..., description="Beneficiary deductible in cents")
-    beneficiary_coinsurance_cents: int = Field(..., description="Beneficiary coinsurance in cents")
-    beneficiary_total_cents: int = Field(..., description="Total beneficiary cost in cents")
+    beneficiary_deductible_cents: int = Field(
+        ..., description="Beneficiary deductible in cents"
+    )
+    beneficiary_coinsurance_cents: int = Field(
+        ..., description="Beneficiary coinsurance in cents"
+    )
+    beneficiary_total_cents: int = Field(
+        ..., description="Total beneficiary cost in cents"
+    )
     program_payment_cents: int = Field(..., description="Program payment in cents")
-    
+
     # Component breakdown
-    professional_allowed_cents: Optional[int] = Field(None, description="Professional component allowed")
-    facility_allowed_cents: Optional[int] = Field(None, description="Facility component allowed")
-    
+    professional_allowed_cents: Optional[int] = Field(
+        None, description="Professional component allowed"
+    )
+    facility_allowed_cents: Optional[int] = Field(
+        None, description="Facility component allowed"
+    )
+
     # Source information
     source: str = Field(..., description="Data source (benchmark, mrf, tic)")
-    facility_specific: bool = Field(default=False, description="Whether facility-specific rate was used")
+    facility_specific: bool = Field(
+        default=False, description="Whether facility-specific rate was used"
+    )
     packaged: bool = Field(default=False, description="Whether item is packaged")
-    
+
     # Drug-specific fields
-    reference_price_cents: Optional[int] = Field(None, description="NADAC reference price")
-    unit_conversion: Optional[Dict[str, Any]] = Field(None, description="Unit conversion details")
-    
+    reference_price_cents: Optional[int] = Field(
+        None, description="NADAC reference price"
+    )
+    unit_conversion: Optional[Dict[str, Any]] = Field(
+        None, description="Unit conversion details"
+    )
+
     # Trace references
     trace_refs: List[str] = Field(
         default_factory=list,
@@ -181,15 +253,12 @@ class LineItemResponse(BaseModel):
     - Provenance references (Phase 2): '{dataset_id}:release:{release_id}' or '{dataset_id}:batch:{batch_id}'
       Examples: 'MPFS:release:mpfs_2025_annual_20250115', 'MPFS:batch:batch_abc123'
     
-    Duplicates are automatically removed to keep logs clean."""
+    Duplicates are automatically removed to keep logs clean.""",
     )
-    
+
     @classmethod
     def from_code_pricing_item(
-        cls,
-        item: "CodePricingItem",
-        sequence: int,
-        utilization_weight: float = 1.0
+        cls, item: "CodePricingItem", sequence: int, utilization_weight: float = 1.0
     ) -> "LineItemResponse":
         """Create LineItemResponse from CodePricingItem (Quick Win #2 compatibility adapter)"""
         return cls(
@@ -210,12 +279,13 @@ class LineItemResponse(BaseModel):
             packaged=item.packaged,
             reference_price_cents=item.reference_price_cents,
             unit_conversion=item.unit_conversion,
-            trace_refs=item.trace_refs
+            trace_refs=item.trace_refs,
         )
 
 
 class GeographyResponse(BaseModel):
     """Geography information in pricing response"""
+
     zip5: str = Field(..., description="5-digit ZIP code")
     locality_id: Optional[str] = Field(None, description="Selected MPFS locality")
     locality_name: Optional[str] = Field(None, description="Locality name")
@@ -223,36 +293,53 @@ class GeographyResponse(BaseModel):
     cbsa_name: Optional[str] = Field(None, description="CBSA name")
     county_fips: Optional[str] = Field(None, description="County FIPS")
     state_code: Optional[str] = Field(None, description="State code")
-    rural_flag: Optional[str] = Field(default=None, description="Rural indicator (R, B, or blank) per PRD")
+    rural_flag: Optional[str] = Field(
+        default=None, description="Rural indicator (R, B, or blank) per PRD"
+    )
     resolution_method: str = Field(..., description="Resolution method used")
-    candidates: List[GeographyCandidate] = Field(..., description="All candidates considered")
+    candidates: List[GeographyCandidate] = Field(
+        ..., description="All candidates considered"
+    )
 
 
 class PricingResponse(BaseModel):
     """Response schema for pricing a plan"""
+
     run_id: str = Field(..., description="Unique run identifier")
     plan_id: Optional[UUID] = Field(None, description="Plan ID")
     plan_name: Optional[str] = Field(None, description="Plan name")
-    
+
     # Geography
     geography: GeographyResponse = Field(..., description="Geography information")
-    
+
     # Line items
     line_items: List[LineItemResponse] = Field(..., description="Pricing line items")
-    
+
     # Totals
     total_allowed_cents: int = Field(..., description="Total Medicare allowed")
-    total_beneficiary_deductible_cents: int = Field(..., description="Total beneficiary deductible")
-    total_beneficiary_coinsurance_cents: int = Field(..., description="Total beneficiary coinsurance")
+    total_beneficiary_deductible_cents: int = Field(
+        ..., description="Total beneficiary deductible"
+    )
+    total_beneficiary_coinsurance_cents: int = Field(
+        ..., description="Total beneficiary coinsurance"
+    )
     total_beneficiary_cents: int = Field(..., description="Total beneficiary cost")
     total_program_payment_cents: int = Field(..., description="Total program payment")
-    remaining_part_b_deductible_cents: int = Field(..., description="Remaining Part B deductible")
-    
+    remaining_part_b_deductible_cents: int = Field(
+        ..., description="Remaining Part B deductible"
+    )
+
     # Flags and metadata
-    post_acute_included: bool = Field(default=False, description="Post-acute care included")
-    sequestration_applied: bool = Field(default=False, description="Sequestration applied")
-    facility_specific_used: bool = Field(default=False, description="Facility-specific rates used")
-    
+    post_acute_included: bool = Field(
+        default=False, description="Post-acute care included"
+    )
+    sequestration_applied: bool = Field(
+        default=False, description="Sequestration applied"
+    )
+    facility_specific_used: bool = Field(
+        default=False, description="Facility-specific rates used"
+    )
+
     # Dataset information
     datasets_used: List[Dict[str, Any]] = Field(
         ...,
@@ -277,20 +364,29 @@ class PricingResponse(BaseModel):
             "effective_from": "2025-01-01",
             "effective_to": None
         }
-    ]"""
+    ]""",
     )
-    
+
     # Warnings
     warnings: List[str] = Field(default_factory=list, description="Pricing warnings")
 
 
 class ComparisonRequest(BaseModel):
     """Request schema for comparing two locations"""
-    zip_a: str = Field(..., min_length=5, max_length=5, description="Location A ZIP code")
-    zip_b: str = Field(..., min_length=5, max_length=5, description="Location B ZIP code")
+
+    zip_a: str = Field(
+        ..., min_length=5, max_length=5, description="Location A ZIP code"
+    )
+    zip_b: str = Field(
+        ..., min_length=5, max_length=5, description="Location B ZIP code"
+    )
     plan_id: Optional[UUID] = Field(None, description="Plan ID")
     year: int = Field(..., ge=2020, le=2030, description="Valuation year")
-    quarter: Optional[str] = Field(None, pattern=r'^[1-4]$', description="Quarter")
+    quarter: Optional[str] = Field(None, pattern=r"^[1-4]$", description="Quarter")
+    valuation_date: Optional[date] = Field(
+        None,
+        description="Exact valuation date; overrides quarter for snapshot selection",
+    )
     ccn_a: Optional[str] = Field(None, max_length=6, description="Location A CCN")
     ccn_b: Optional[str] = Field(None, max_length=6, description="Location B CCN")
     payer: Optional[str] = Field(None, description="Payer name filter")
@@ -298,36 +394,43 @@ class ComparisonRequest(BaseModel):
     include_home_health: bool = Field(default=False, description="Include home health")
     include_snf: bool = Field(default=False, description="Include SNF")
     apply_sequestration: bool = Field(default=False, description="Apply sequestration")
-    sequestration_rate: float = Field(default=0.02, ge=0, le=0.1, description="Sequestration rate")
-    format: str = Field(default="cents", pattern=r'^(cents|decimal)$', description="Money format")
-    
+    sequestration_rate: float = Field(
+        default=0.02, ge=0, le=0.1, description="Sequestration rate"
+    )
+    format: str = Field(
+        default="cents", pattern=r"^(cents|decimal)$", description="Money format"
+    )
+
     # Ad-hoc plan (alternative to plan_id)
-    ad_hoc_plan: Optional[Dict[str, Any]] = Field(None, description="Ad-hoc plan definition")
-    
-    @field_validator('zip_a', 'zip_b')
+    ad_hoc_plan: Optional[Dict[str, Any]] = Field(
+        None, description="Ad-hoc plan definition"
+    )
+
+    @field_validator("zip_a", "zip_b")
     @classmethod
     def validate_zip(cls, v):
         if not v.isdigit():
-            raise ValueError('ZIP must contain only digits')
+            raise ValueError("ZIP must contain only digits")
         return v
-    
-    @field_validator('ccn_a', 'ccn_b')
+
+    @field_validator("ccn_a", "ccn_b")
     @classmethod
     def validate_ccn(cls, v):
         if v is not None and (not v.isdigit() or len(v) != 6):
-            raise ValueError('CCN must be exactly 6 digits')
+            raise ValueError("CCN must be exactly 6 digits")
         return v
-    
-    @field_validator('quarter')
+
+    @field_validator("quarter")
     @classmethod
     def validate_quarter(cls, v):
-        if v is not None and v not in ['1', '2', '3', '4']:
-            raise ValueError('Quarter must be 1, 2, 3, or 4')
+        if v is not None and v not in ["1", "2", "3", "4"]:
+            raise ValueError("Quarter must be 1, 2, 3, or 4")
         return v
 
 
 class ComparisonDelta(BaseModel):
     """Delta between two pricing results"""
+
     field: str = Field(..., description="Field name")
     location_a: int = Field(..., description="Value for location A (cents)")
     location_b: int = Field(..., description="Value for location B (cents)")
@@ -337,22 +440,23 @@ class ComparisonDelta(BaseModel):
 
 class ComparisonResponse(BaseModel):
     """Response schema for comparing two locations"""
+
     run_id: str = Field(..., description="Unique run identifier")
     plan_id: Optional[UUID] = Field(None, description="Plan ID")
     plan_name: Optional[str] = Field(None, description="Plan name")
-    
+
     # Location A results
     location_a: PricingResponse = Field(..., description="Location A pricing results")
-    
+
     # Location B results
     location_b: PricingResponse = Field(..., description="Location B pricing results")
-    
+
     # Comparison deltas
     deltas: List[ComparisonDelta] = Field(..., description="Field-by-field differences")
-    
+
     # Parity report
     parity_report: Dict[str, Any] = Field(..., description="Parity validation report")
-    
+
     # Summary
     total_delta_cents: int = Field(..., description="Total allowed difference")
     total_delta_percent: float = Field(..., description="Total percentage difference")

--- a/cms_pricing/services/pricing.py
+++ b/cms_pricing/services/pricing.py
@@ -5,8 +5,13 @@ from typing import Dict, Any, List, Optional
 from datetime import date, datetime
 
 from cms_pricing.schemas.pricing import (
-    PricingRequest, PricingResponse, ComparisonRequest, ComparisonResponse,
-    LineItemResponse, GeographyResponse, ComparisonDelta
+    PricingRequest,
+    PricingResponse,
+    ComparisonRequest,
+    ComparisonResponse,
+    LineItemResponse,
+    GeographyResponse,
+    ComparisonDelta,
 )
 from cms_pricing.schemas.geography import GeographyCandidate, GeographyResolveResponse
 from cms_pricing.services.geography import GeographyService
@@ -23,6 +28,7 @@ from cms_pricing.engines.ipps import IPPSEngine
 from cms_pricing.engines.clfs import CLFSEngine
 from cms_pricing.engines.dmepos import DMEPOSEngine
 from cms_pricing.engines.drugs import DrugEngine
+from cms_pricing.services.dataset_snapshot_service import DatasetSnapshotService
 import structlog
 
 logger = structlog.get_logger()
@@ -30,7 +36,7 @@ logger = structlog.get_logger()
 
 class PricingService:
     """Main pricing service"""
-    
+
     def __init__(self, db: Session = None):
         self.db = db
         self.geography_service = GeographyService(db)
@@ -38,13 +44,13 @@ class PricingService:
         self._plan_name_cache: Dict[Any, str] = {}
         # Pass db session to engines for connection reuse (optimization)
         self.engines = {
-            'MPFS': MPSFEngine(db=db),
-            'OPPS': OPPSEngine(db=db),
-            'ASC': ASCEngine(db=db),
-            'IPPS': IPPSEngine(db=db),
-            'CLFS': CLFSEngine(db=db),
-            'DMEPOS': DMEPOSEngine(db=db),
-            'DRUGS': DrugEngine(db=db)
+            "MPFS": MPSFEngine(db=db),
+            "OPPS": OPPSEngine(db=db),
+            "ASC": ASCEngine(db=db),
+            "IPPS": IPPSEngine(db=db),
+            "CLFS": CLFSEngine(db=db),
+            "DMEPOS": DMEPOSEngine(db=db),
+            "DRUGS": DrugEngine(db=db),
         }
 
     def _candidate_from_mapping(
@@ -77,7 +83,9 @@ class PricingService:
             return result
 
         if not isinstance(result, dict):
-            raise TypeError(f"Unsupported geography result type: {type(result).__name__}")
+            raise TypeError(
+                f"Unsupported geography result type: {type(result).__name__}"
+            )
 
         normalized_zip = result.get("zip5") or zip5
 
@@ -85,7 +93,9 @@ class PricingService:
         if isinstance(selected_candidate, GeographyCandidate):
             selected = selected_candidate
         elif isinstance(selected_candidate, dict):
-            selected = self._candidate_from_mapping(normalized_zip, selected_candidate, used=True)
+            selected = self._candidate_from_mapping(
+                normalized_zip, selected_candidate, used=True
+            )
         else:
             selected = None
 
@@ -111,10 +121,14 @@ class PricingService:
         return GeographyResolveResponse(
             zip5=normalized_zip,
             candidates=candidates,
-            requires_resolution=bool(result.get("requires_resolution", selected is None)),
+            requires_resolution=bool(
+                result.get("requires_resolution", selected is None)
+            ),
             ambiguity_threshold=float(result.get("ambiguity_threshold", 0.2)),
             selected_candidate=selected,
-            resolution_method=result.get("resolution_method") or result.get("match_level") or "unknown",
+            resolution_method=result.get("resolution_method")
+            or result.get("match_level")
+            or "unknown",
             warnings=list(result.get("warnings") or []),
         )
 
@@ -136,7 +150,7 @@ class PricingService:
             resolution_method=geography_result.resolution_method,
             candidates=geography_result.candidates,
         )
-    
+
     async def price_single_code(
         self,
         zip: str,
@@ -144,49 +158,64 @@ class PricingService:
         setting: str,
         year: int,
         quarter: Optional[str] = None,
+        valuation_date: Optional[date] = None,
         ccn: Optional[str] = None,
         payer: Optional[str] = None,
-        plan: Optional[str] = None
+        plan: Optional[str] = None,
+        pos: Optional[str] = None,
     ) -> "CodePricingItemWithGeography":
         """Price a single code/component (returns CodePricingItemWithGeography)"""
-        
+
         from cms_pricing.schemas.pricing import CodePricingItemWithGeography
-        
+
         run_id = str(uuid.uuid4())
-        
+
         try:
+            selected_valuation_date = self._valuation_date_from_inputs(
+                year=year,
+                quarter=quarter,
+                valuation_date=valuation_date,
+            )
             # Resolve geography
             geography_result = self._normalize_geography_result(
                 zip,
-                await self.geography_service.resolve_zip(zip),
+                await self.geography_service.resolve_zip(
+                    zip,
+                    valuation_year=year,
+                    quarter=int(quarter) if quarter else None,
+                    valuation_date=valuation_date,
+                ),
             )
-            
+
             # Get appropriate engine
             engine = self.engines.get(setting)
             if not engine:
                 raise ValueError(f"Unknown setting: {setting}")
-            
+
             # Price the code (returns CodePricingItem)
-            result = await engine.price_code(
-                code=code,
-                zip=zip,
-                year=year,
-                quarter=quarter,
-                geography=geography_result,
-                ccn=ccn,
-                payer=payer,
-                plan=plan
-            )
-            
+            price_kwargs = {
+                "code": code,
+                "zip": zip,
+                "year": year,
+                "quarter": quarter,
+                "geography": geography_result,
+                "ccn": ccn,
+                "payer": payer,
+                "plan": plan,
+                "pos": pos,
+            }
+            if setting == "MPFS":
+                price_kwargs["valuation_date"] = selected_valuation_date
+
+            result = await engine.price_code(**price_kwargs)
+
             geography_response = self._build_geography_response(geography_result)
-            
+
             # Return CodePricingItemWithGeography (Quick Win #2)
             return CodePricingItemWithGeography(
-                **result.model_dump(),
-                geography=geography_response,
-                run_id=run_id
+                **result.model_dump(), geography=geography_response, run_id=run_id
             )
-            
+
         except Exception as e:
             logger.error(
                 "Single code pricing failed",
@@ -195,22 +224,32 @@ class PricingService:
                 code=code,
                 setting=setting,
                 error=str(e),
-                exc_info=True
+                exc_info=True,
             )
             raise
-    
+
     async def price_plan(self, request: PricingRequest) -> PricingResponse:
         """Price a complete treatment plan"""
-        
+
         run_id = str(uuid.uuid4())
-        
+
         try:
+            valuation_date = self._valuation_date_from_inputs(
+                year=request.year,
+                quarter=request.quarter,
+                valuation_date=request.valuation_date,
+            )
             # Resolve geography
             geography_result = self._normalize_geography_result(
                 request.zip,
-                await self.geography_service.resolve_zip(request.zip),
+                await self.geography_service.resolve_zip(
+                    request.zip,
+                    valuation_year=request.year,
+                    quarter=int(request.quarter) if request.quarter else None,
+                    valuation_date=request.valuation_date,
+                ),
             )
-            
+
             # Get plan components
             if request.plan_id:
                 # Load from database
@@ -220,10 +259,10 @@ class PricingService:
                 # Use ad-hoc plan
                 ad_hoc_plan = request.ad_hoc_plan or {}
                 components = self._normalize_ad_hoc_components(
-                    ad_hoc_plan.get('components', [])
+                    ad_hoc_plan.get("components", [])
                 )
-                plan_name = ad_hoc_plan.get('name', 'Ad-hoc Plan')
-            
+                plan_name = ad_hoc_plan.get("name", "Ad-hoc Plan")
+
             # Price each component
             line_items = []
             total_allowed_cents = 0
@@ -232,37 +271,41 @@ class PricingService:
             total_beneficiary_cents = 0
             total_program_payment_cents = 0
             datasets_seen = set()  # Track unique datasets used
-            
+
             for i, component in enumerate(components):
                 # Get appropriate engine
-                engine = self.engines.get(component['setting'])
+                engine = self.engines.get(component["setting"])
                 if not engine:
                     logger.warning(
                         "Unknown setting for component",
                         run_id=run_id,
-                        code=component['code'],
-                        setting=component['setting']
+                        code=component["code"],
+                        setting=component["setting"],
                     )
                     continue
-                
+
                 # Price the component (returns CodePricingItem)
-                result = await engine.price_code(
-                    code=component['code'],
-                    zip=request.zip,
-                    year=request.year,
-                    quarter=request.quarter,
-                    geography=geography_result,
-                    ccn=request.ccn,
-                    payer=request.payer,
-                    plan=request.plan,
-                    units=component['units'],
-                    utilization_weight=component['utilization_weight'],
-                    professional_component=component['professional_component'],
-                    facility_component=component['facility_component'],
-                    modifiers=component['modifiers'],
-                    pos=component['pos'],
-                    ndc11=component['ndc11']
-                )
+                price_kwargs = {
+                    "code": component["code"],
+                    "zip": request.zip,
+                    "year": request.year,
+                    "quarter": request.quarter,
+                    "geography": geography_result,
+                    "ccn": request.ccn,
+                    "payer": request.payer,
+                    "plan": request.plan,
+                    "units": component["units"],
+                    "utilization_weight": component["utilization_weight"],
+                    "professional_component": component["professional_component"],
+                    "facility_component": component["facility_component"],
+                    "modifiers": component["modifiers"],
+                    "pos": component["pos"],
+                    "ndc11": component["ndc11"],
+                }
+                if component["setting"] == "MPFS":
+                    price_kwargs["valuation_date"] = valuation_date
+
+                result = await engine.price_code(**price_kwargs)
 
                 # Track dataset used from authoritative CodePricingItem.dataset_id (Quick Win #2)
                 if result.dataset_id:
@@ -272,28 +315,33 @@ class PricingService:
                 line_item = LineItemResponse.from_code_pricing_item(
                     item=result,
                     sequence=i + 1,
-                    utilization_weight=component['utilization_weight']
+                    utilization_weight=component["utilization_weight"],
                 )
-                
+
                 line_items.append(line_item)
-                
+
                 # Accumulate totals using CodePricingItem attributes
                 total_allowed_cents += result.allowed_cents
-                total_beneficiary_deductible_cents += result.beneficiary_deductible_cents
-                total_beneficiary_coinsurance_cents += result.beneficiary_coinsurance_cents
+                total_beneficiary_deductible_cents += (
+                    result.beneficiary_deductible_cents
+                )
+                total_beneficiary_coinsurance_cents += (
+                    result.beneficiary_coinsurance_cents
+                )
                 total_beneficiary_cents += result.beneficiary_total_cents
                 total_program_payment_cents += result.program_payment_cents
-            
+
             geography_response = self._build_geography_response(geography_result)
-            
+
             # Collect dataset snapshots for provenance (Phase 2.6)
             datasets_used = self._collect_datasets_used(
                 datasets_seen=datasets_seen,
                 valuation_year=request.year,
                 valuation_quarter=request.quarter,
-                line_items=line_items
+                valuation_date=valuation_date,
+                line_items=line_items,
             )
-            
+
             # Create response
             response = PricingResponse(
                 run_id=run_id,
@@ -309,31 +357,33 @@ class PricingService:
                 remaining_part_b_deductible_cents=0,  # TODO(alex, GH-424): Calculate remaining deductible
                 post_acute_included=request.include_home_health or request.include_snf,
                 sequestration_applied=request.apply_sequestration,
-                facility_specific_used=any(item.facility_specific for item in line_items),
+                facility_specific_used=any(
+                    item.facility_specific for item in line_items
+                ),
                 datasets_used=datasets_used,
-                warnings=geography_result.warnings
+                warnings=geography_result.warnings,
             )
-            
+
             # Store trace
             await self.trace_service.store_run(
                 run_id=run_id,
                 endpoint="/pricing/price",
                 request_data=request.dict(),
                 response_data=response.dict(),
-                status="success"
+                status="success",
             )
-            
+
             return response
-            
+
         except Exception as e:
             logger.error(
                 "Plan pricing failed",
                 run_id=run_id,
                 request=request.dict(),
                 error=str(e),
-                exc_info=True
+                exc_info=True,
             )
-            
+
             # Store error trace
             await self.trace_service.store_run(
                 run_id=run_id,
@@ -341,16 +391,16 @@ class PricingService:
                 request_data=request.dict(),
                 response_data=None,
                 status="error",
-                error_message=str(e)
+                error_message=str(e),
             )
-            
+
             raise
-    
+
     async def compare_locations(self, request: ComparisonRequest) -> ComparisonResponse:
         """Compare pricing between two locations"""
-        
+
         run_id = str(uuid.uuid4())
-        
+
         try:
             # Price location A
             request_a = PricingRequest(
@@ -358,6 +408,7 @@ class PricingService:
                 plan_id=request.plan_id,
                 year=request.year,
                 quarter=request.quarter,
+                valuation_date=request.valuation_date,
                 ccn=request.ccn_a,
                 payer=request.payer,
                 plan=request.plan,
@@ -366,17 +417,18 @@ class PricingService:
                 apply_sequestration=request.apply_sequestration,
                 sequestration_rate=request.sequestration_rate,
                 format=request.format,
-                ad_hoc_plan=request.ad_hoc_plan
+                ad_hoc_plan=request.ad_hoc_plan,
             )
-            
+
             result_a = await self.price_plan(request_a)
-            
+
             # Price location B
             request_b = PricingRequest(
                 zip=request.zip_b,
                 plan_id=request.plan_id,
                 year=request.year,
                 quarter=request.quarter,
+                valuation_date=request.valuation_date,
                 ccn=request.ccn_b,
                 payer=request.payer,
                 plan=request.plan,
@@ -385,17 +437,19 @@ class PricingService:
                 apply_sequestration=request.apply_sequestration,
                 sequestration_rate=request.sequestration_rate,
                 format=request.format,
-                ad_hoc_plan=request.ad_hoc_plan
+                ad_hoc_plan=request.ad_hoc_plan,
             )
-            
+
             result_b = await self.price_plan(request_b)
-            
+
             # Validate parity
-            parity_report = self._validate_parity(request_a, request_b, result_a, result_b)
-            
+            parity_report = self._validate_parity(
+                request_a, request_b, result_a, result_b
+            )
+
             # Calculate deltas
             deltas = self._calculate_deltas(result_a, result_b)
-            
+
             # Create comparison response
             response = ComparisonResponse(
                 run_id=run_id,
@@ -405,33 +459,33 @@ class PricingService:
                 location_b=result_b,
                 deltas=deltas,
                 parity_report=parity_report,
-                total_delta_cents=result_b.total_allowed_cents - result_a.total_allowed_cents,
+                total_delta_cents=result_b.total_allowed_cents
+                - result_a.total_allowed_cents,
                 total_delta_percent=self._calculate_percentage_delta(
-                    result_a.total_allowed_cents,
-                    result_b.total_allowed_cents
-                )
+                    result_a.total_allowed_cents, result_b.total_allowed_cents
+                ),
             )
-            
+
             # Store trace
             await self.trace_service.store_run(
                 run_id=run_id,
                 endpoint="/pricing/compare",
                 request_data=request.dict(),
                 response_data=response.dict(),
-                status="success"
+                status="success",
             )
-            
+
             return response
-            
+
         except Exception as e:
             logger.error(
                 "Location comparison failed",
                 run_id=run_id,
                 request=request.dict(),
                 error=str(e),
-                exc_info=True
+                exc_info=True,
             )
-            
+
             # Store error trace
             await self.trace_service.store_run(
                 run_id=run_id,
@@ -439,93 +493,128 @@ class PricingService:
                 request_data=request.dict(),
                 response_data=None,
                 status="error",
-                error_message=str(e)
+                error_message=str(e),
             )
-            
+
             raise
-    
+
     def _validate_parity(
         self,
         request_a: PricingRequest,
         request_b: PricingRequest,
         result_a: PricingResponse,
-        result_b: PricingResponse
+        result_b: PricingResponse,
     ) -> Dict[str, Any]:
         """Validate parity between two pricing requests"""
-        
+
         parity_report = {
             "valid": True,
             "violations": [],
             "snapshots_match": True,
             "benefits_match": True,
             "toggles_match": True,
-            "plan_match": True
+            "plan_match": True,
         }
-        
+
         # Check snapshot parity
         if result_a.datasets_used != result_b.datasets_used:
             parity_report["valid"] = False
             parity_report["violations"].append("Dataset snapshots differ")
             parity_report["snapshots_match"] = False
-        
+
         # Check benefit parity
-        if (request_a.include_home_health != request_b.include_home_health or
-            request_a.include_snf != request_b.include_snf):
+        if (
+            request_a.include_home_health != request_b.include_home_health
+            or request_a.include_snf != request_b.include_snf
+        ):
             parity_report["valid"] = False
             parity_report["violations"].append("Post-acute settings differ")
             parity_report["benefits_match"] = False
-        
+
         # Check toggle parity
-        if (request_a.apply_sequestration != request_b.apply_sequestration or
-            request_a.sequestration_rate != request_b.sequestration_rate):
+        if (
+            request_a.apply_sequestration != request_b.apply_sequestration
+            or request_a.sequestration_rate != request_b.sequestration_rate
+        ):
             parity_report["valid"] = False
             parity_report["violations"].append("Policy toggles differ")
             parity_report["toggles_match"] = False
-        
+
         # Check plan parity
         if request_a.plan_id != request_b.plan_id:
             parity_report["valid"] = False
             parity_report["violations"].append("Plan IDs differ")
             parity_report["plan_match"] = False
-        
+
         return parity_report
-    
-    def _calculate_deltas(self, result_a: PricingResponse, result_b: PricingResponse) -> List[ComparisonDelta]:
+
+    def _calculate_deltas(
+        self, result_a: PricingResponse, result_b: PricingResponse
+    ) -> List[ComparisonDelta]:
         """Calculate deltas between two pricing results"""
-        
+
         deltas = []
-        
+
         # Total deltas
-        deltas.append(ComparisonDelta(
-            field="total_allowed",
-            location_a=result_a.total_allowed_cents,
-            location_b=result_b.total_allowed_cents,
-            delta_cents=result_b.total_allowed_cents - result_a.total_allowed_cents,
-            delta_percent=self._calculate_percentage_delta(
-                result_a.total_allowed_cents,
-                result_b.total_allowed_cents
+        deltas.append(
+            ComparisonDelta(
+                field="total_allowed",
+                location_a=result_a.total_allowed_cents,
+                location_b=result_b.total_allowed_cents,
+                delta_cents=result_b.total_allowed_cents - result_a.total_allowed_cents,
+                delta_percent=self._calculate_percentage_delta(
+                    result_a.total_allowed_cents, result_b.total_allowed_cents
+                ),
             )
-        ))
-        
-        deltas.append(ComparisonDelta(
-            field="total_beneficiary",
-            location_a=result_a.total_beneficiary_cents,
-            location_b=result_b.total_beneficiary_cents,
-            delta_cents=result_b.total_beneficiary_cents - result_a.total_beneficiary_cents,
-            delta_percent=self._calculate_percentage_delta(
-                result_a.total_beneficiary_cents,
-                result_b.total_beneficiary_cents
+        )
+
+        deltas.append(
+            ComparisonDelta(
+                field="total_beneficiary",
+                location_a=result_a.total_beneficiary_cents,
+                location_b=result_b.total_beneficiary_cents,
+                delta_cents=result_b.total_beneficiary_cents
+                - result_a.total_beneficiary_cents,
+                delta_percent=self._calculate_percentage_delta(
+                    result_a.total_beneficiary_cents, result_b.total_beneficiary_cents
+                ),
             )
-        ))
-        
+        )
+
         return deltas
-    
+
     def _calculate_percentage_delta(self, value_a: int, value_b: int) -> float:
         """Calculate percentage delta between two values"""
         if value_a == 0:
-            return 0.0 if value_b == 0 else float('inf')
+            return 0.0 if value_b == 0 else float("inf")
         return ((value_b - value_a) / value_a) * 100
-    
+
+    @staticmethod
+    def _valuation_date_from_inputs(
+        *,
+        year: int,
+        quarter: Optional[str],
+        valuation_date: Optional[date],
+    ) -> date:
+        if valuation_date is not None:
+            if valuation_date.year != year:
+                raise ValueError(
+                    f"valuation_date year {valuation_date.year} does not match year {year}"
+                )
+            return valuation_date
+
+        if quarter:
+            quarter_starts = {
+                "1": (1, 1),
+                "2": (4, 1),
+                "3": (7, 1),
+                "4": (10, 1),
+            }
+            month, day = quarter_starts[str(quarter)]
+            return date(year, month, day)
+
+        return date(year, 12, 31)
+
     async def _load_plan_components(self, plan_id) -> List[Dict[str, Any]]:
         """Load plan components from database"""
         if not self.db:
@@ -570,7 +659,7 @@ class PricingService:
 
         # Already ordered via query; no additional sort required
         return normalized_components
-    
+
     async def _get_plan_name(self, plan_id) -> str:
         """Get plan name from database, using cached value when available"""
         if plan_id in self._plan_name_cache:
@@ -586,7 +675,9 @@ class PricingService:
         self._plan_name_cache[plan_id] = plan.name
         return plan.name
 
-    def _normalize_ad_hoc_components(self, components: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    def _normalize_ad_hoc_components(
+        self, components: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
         """Normalize ad-hoc plan components to match stored plan structure"""
         if not components:
             return []
@@ -594,14 +685,16 @@ class PricingService:
         normalized: List[Dict[str, Any]] = []
         for idx, raw_component in enumerate(components):
             # Use explicit sequence if provided, otherwise fallback to index ordering
-            provided_sequence = raw_component.get('sequence')
-            fallback_sequence = provided_sequence if provided_sequence is not None else idx + 1
+            provided_sequence = raw_component.get("sequence")
+            fallback_sequence = (
+                provided_sequence if provided_sequence is not None else idx + 1
+            )
             normalized.append(
                 self._apply_component_defaults(raw_component, fallback_sequence)
             )
 
         # Preserve explicit sequencing
-        normalized.sort(key=lambda component: component['sequence'])
+        normalized.sort(key=lambda component: component["sequence"])
         return normalized
 
     def _apply_component_defaults(
@@ -611,19 +704,23 @@ class PricingService:
     ) -> Dict[str, Any]:
         """Apply default values and type normalization for plan components"""
 
-        code = raw_component.get('code')
-        setting = raw_component.get('setting')
+        code = raw_component.get("code")
+        setting = raw_component.get("setting")
         if not code or not setting:
             raise ValueError("Plan components must include both 'code' and 'setting'")
 
         # Normalize modifiers
-        modifiers_value = raw_component.get('modifiers')
+        modifiers_value = raw_component.get("modifiers")
         if modifiers_value is None:
             modifiers: List[str] = []
         elif isinstance(modifiers_value, list):
-            modifiers = [str(mod).strip() for mod in modifiers_value if str(mod).strip()]
+            modifiers = [
+                str(mod).strip() for mod in modifiers_value if str(mod).strip()
+            ]
         elif isinstance(modifiers_value, str):
-            modifiers = [part.strip() for part in modifiers_value.split(',') if part.strip()]
+            modifiers = [
+                part.strip() for part in modifiers_value.split(",") if part.strip()
+            ]
         else:
             modifiers = [str(modifiers_value).strip()]
 
@@ -636,7 +733,7 @@ class PricingService:
                 return default
 
         fallback_sequence_int = _to_int(fallback_sequence, 1)
-        sequence_value = raw_component.get('sequence')
+        sequence_value = raw_component.get("sequence")
         sequence = _to_int(sequence_value, fallback_sequence_int)
 
         def _to_bool(value: Any, default: bool) -> bool:
@@ -664,44 +761,59 @@ class PricingService:
         normalized_component = {
             "code": str(code).strip(),
             "setting": str(setting).strip().upper(),
-            "units": _to_float(raw_component.get('units'), 1.0),
-            "utilization_weight": _to_float(raw_component.get('utilization_weight'), 1.0),
-            "professional_component": _to_bool(raw_component.get('professional_component'), True),
-            "facility_component": _to_bool(raw_component.get('facility_component'), True),
+            "units": _to_float(raw_component.get("units"), 1.0),
+            "utilization_weight": _to_float(
+                raw_component.get("utilization_weight"), 1.0
+            ),
+            "professional_component": _to_bool(
+                raw_component.get("professional_component"), True
+            ),
+            "facility_component": _to_bool(
+                raw_component.get("facility_component"), True
+            ),
             "modifiers": modifiers,
-            "pos": str(raw_component.get('pos')).strip() if raw_component.get('pos') is not None else None,
-            "ndc11": str(raw_component.get('ndc11')).strip() if raw_component.get('ndc11') is not None else None,
-            "wastage_units": _to_float(raw_component.get('wastage_units'), 0.0),
+            "pos": str(raw_component.get("pos")).strip()
+            if raw_component.get("pos") is not None
+            else None,
+            "ndc11": str(raw_component.get("ndc11")).strip()
+            if raw_component.get("ndc11") is not None
+            else None,
+            "wastage_units": _to_float(raw_component.get("wastage_units"), 0.0),
             "sequence": sequence,
         }
 
         return normalized_component
-    
+
     def _collect_datasets_used(
         self,
         datasets_seen: set,
         valuation_year: int,
         valuation_quarter: Optional[str] = None,
-        line_items: Optional[List[LineItemResponse]] = None
+        valuation_date: Optional[date] = None,
+        line_items: Optional[List[LineItemResponse]] = None,
     ) -> List[Dict[str, Any]]:
         """
         Collect active dataset snapshot information for provenance.
-        
+
         Enhanced to include release_id/batch_id from engine results when available (Phase 2.6).
-        
+
         Args:
             datasets_seen: Set of dataset IDs (e.g., {'MPFS', 'OPPS'})
             valuation_year: Year for which data is being queried
             valuation_quarter: Optional quarter (1-4)
             line_items: Optional list of line items to extract provenance from trace_refs
-            
+
         Returns:
             List of dataset metadata dictionaries with snapshot information including release_id/batch_id
         """
         if not self.db:
             # If no DB, extract provenance from line_items if available
-            release_map = self._extract_provenance_from_line_items(line_items, datasets_seen) if line_items else {}
-            
+            release_map = (
+                self._extract_provenance_from_line_items(line_items, datasets_seen)
+                if line_items
+                else {}
+            )
+
             return [
                 {
                     "dataset_id": ds,
@@ -710,176 +822,206 @@ class PricingService:
                     "effective_to": None,
                     "source_url": None,
                     "release_id": release_map.get(ds, {}).get("release_id"),
-                    "batch_id": release_map.get(ds, {}).get("batch_id")
+                    "batch_id": release_map.get(ds, {}).get("batch_id"),
                 }
                 for ds in sorted(datasets_seen)
             ]
-        
+
         datasets_used = []
-        valuation_date = date(valuation_year, 12, 31)  # Use end of year as valuation date
-        
+        selected_valuation_date = self._valuation_date_from_inputs(
+            year=valuation_year,
+            quarter=valuation_quarter,
+            valuation_date=valuation_date,
+        )
+
         # Extract release_id/batch_id from line items if available (Phase 2.6)
-        release_map = self._extract_provenance_from_line_items(line_items, datasets_seen) if line_items else {}
-        
+        release_map = (
+            self._extract_provenance_from_line_items(line_items, datasets_seen)
+            if line_items
+            else {}
+        )
+
         for dataset_id in sorted(datasets_seen):
             try:
                 # Try DatasetSnapshot first (Quick Win #1)
-                snapshot = self.db.query(DatasetSnapshot).filter(
-                    and_(
-                        DatasetSnapshot.dataset_id == dataset_id,
-                        DatasetSnapshot.effective_from <= valuation_date,
-                        or_(
-                            DatasetSnapshot.effective_to.is_(None),
-                            DatasetSnapshot.effective_to >= date(valuation_year, 1, 1)
-                        )
-                    )
-                ).order_by(
-                    DatasetSnapshot.effective_from.desc(),
-                    DatasetSnapshot.created_at.desc()
-                ).first()
-                
+                snapshot = DatasetSnapshotService(self.db).select_snapshot(
+                    dataset_id,
+                    valuation_date=selected_valuation_date,
+                )
+
                 # Fallback to legacy Snapshot model if DatasetSnapshot not available
                 if not snapshot:
-                    snapshot = self.db.query(Snapshot).filter(
-                        and_(
-                            Snapshot.dataset_id == dataset_id,
-                            Snapshot.effective_from <= valuation_date,
-                            or_(
-                                Snapshot.effective_to.is_(None),
-                                Snapshot.effective_to >= date(valuation_year, 1, 1)
+                    snapshot = (
+                        self.db.query(Snapshot)
+                        .filter(
+                            and_(
+                                Snapshot.dataset_id == dataset_id,
+                                Snapshot.effective_from <= selected_valuation_date,
+                                or_(
+                                    Snapshot.effective_to.is_(None),
+                                    Snapshot.effective_to >= selected_valuation_date,
+                                ),
                             )
                         )
-                    ).order_by(
-                        Snapshot.effective_from.desc(),
-                        Snapshot.created_at.desc()
-                    ).first()
-                
+                        .order_by(
+                            Snapshot.effective_from.desc(), Snapshot.created_at.desc()
+                        )
+                        .first()
+                    )
+
                 # Get release info if available from engine results
                 release_info = release_map.get(dataset_id, {})
-                
+
                 if snapshot:
                     # Handle both DatasetSnapshot and legacy Snapshot models
                     if isinstance(snapshot, DatasetSnapshot):
-                        datasets_used.append({
-                            "dataset_id": snapshot.dataset_id,
-                            "digest": snapshot.digest,
-                            "effective_from": snapshot.effective_from.isoformat() if snapshot.effective_from else None,
-                            "effective_to": snapshot.effective_to.isoformat() if snapshot.effective_to else None,
-                            "source_url": snapshot.manifest_url,  # DatasetSnapshot uses manifest_url
-                            "release_id": snapshot.release_id or release_info.get("release_id"),  # Use snapshot's release_id if available
-                            "batch_id": release_info.get("batch_id")
-                        })
+                        datasets_used.append(
+                            {
+                                "dataset_id": snapshot.dataset_id,
+                                "digest": snapshot.digest,
+                                "effective_from": snapshot.effective_from.isoformat()
+                                if snapshot.effective_from
+                                else None,
+                                "effective_to": snapshot.effective_to.isoformat()
+                                if snapshot.effective_to
+                                else None,
+                                "source_url": snapshot.manifest_url,  # DatasetSnapshot uses manifest_url
+                                "release_id": snapshot.release_id
+                                or release_info.get(
+                                    "release_id"
+                                ),  # Use snapshot's release_id if available
+                                "batch_id": release_info.get("batch_id"),
+                            }
+                        )
                     else:
                         # Legacy Snapshot model
-                        datasets_used.append({
-                            "dataset_id": snapshot.dataset_id,
-                            "digest": snapshot.digest,
-                            "effective_from": snapshot.effective_from.isoformat() if snapshot.effective_from else None,
-                            "effective_to": snapshot.effective_to.isoformat() if snapshot.effective_to else None,
-                            "source_url": snapshot.source_url,
-                            # NEW: Include release provenance (Phase 2.6)
-                            "release_id": release_info.get("release_id"),
-                            "batch_id": release_info.get("batch_id")
-                        })
+                        datasets_used.append(
+                            {
+                                "dataset_id": snapshot.dataset_id,
+                                "digest": snapshot.digest,
+                                "effective_from": snapshot.effective_from.isoformat()
+                                if snapshot.effective_from
+                                else None,
+                                "effective_to": snapshot.effective_to.isoformat()
+                                if snapshot.effective_to
+                                else None,
+                                "source_url": snapshot.source_url,
+                                # NEW: Include release provenance (Phase 2.6)
+                                "release_id": release_info.get("release_id"),
+                                "batch_id": release_info.get("batch_id"),
+                            }
+                        )
                 else:
                     # No snapshot found - include dataset ID but no provenance
                     logger.debug(
                         "No snapshot found for dataset",
                         dataset_id=dataset_id,
                         valuation_year=valuation_year,
-                        valuation_quarter=valuation_quarter
+                        valuation_quarter=valuation_quarter,
                     )
-                    datasets_used.append({
-                        "dataset_id": dataset_id,
-                        "digest": None,
-                        "effective_from": None,
-                        "effective_to": None,
-                        "source_url": None,
-                        # Include release info if available from engines
-                        "release_id": release_info.get("release_id"),
-                        "batch_id": release_info.get("batch_id")
-                    })
-                    
+                    datasets_used.append(
+                        {
+                            "dataset_id": dataset_id,
+                            "digest": None,
+                            "effective_from": None,
+                            "effective_to": None,
+                            "source_url": None,
+                            # Include release info if available from engines
+                            "release_id": release_info.get("release_id"),
+                            "batch_id": release_info.get("batch_id"),
+                        }
+                    )
+
             except Exception as e:
                 logger.warning(
                     "Failed to query snapshot for dataset",
                     dataset_id=dataset_id,
                     error=str(e),
-                    exc_info=True
+                    exc_info=True,
                 )
                 # Still include the dataset even if snapshot lookup failed
                 release_info = release_map.get(dataset_id, {})
-                datasets_used.append({
-                    "dataset_id": dataset_id,
-                    "digest": None,
-                    "effective_from": None,
-                    "effective_to": None,
-                    "source_url": None,
-                    "release_id": release_info.get("release_id"),
-                    "batch_id": release_info.get("batch_id")
-                })
-        
+                datasets_used.append(
+                    {
+                        "dataset_id": dataset_id,
+                        "digest": None,
+                        "effective_from": None,
+                        "effective_to": None,
+                        "source_url": None,
+                        "release_id": release_info.get("release_id"),
+                        "batch_id": release_info.get("batch_id"),
+                    }
+                )
+
         return datasets_used
-    
+
     def _extract_provenance_from_line_items(
         self,
         line_items: Optional[List[LineItemResponse]],
         datasets_seen: set,
-        include_supporting_datasets: bool = False
+        include_supporting_datasets: bool = False,
     ) -> Dict[str, Dict[str, Optional[str]]]:
         """
         Extract release_id and batch_id from line items' trace_refs.
-        
+
         Parses standardized trace_refs format: {dataset_id}:release:{release_id} or {dataset_id}:batch:{batch_id}
-        
+
         Args:
             line_items: List of line items with trace_refs
             datasets_seen: Set of primary dataset IDs to filter for (e.g., {'MPFS', 'OPPS'})
             include_supporting_datasets: If True, also extract provenance for supporting datasets
                                          (GPCI, WageIndex, CF, IPPSBaseRate). Default False.
-            
+
         Returns:
             Dictionary mapping dataset_id to {release_id, batch_id}
         """
         if not line_items:
             return {}
-        
+
         release_map: Dict[str, Dict[str, Optional[str]]] = {}
-        
+
         # Known supporting datasets that may appear in trace_refs
-        supporting_datasets = {"GPCI", "CF", "ConversionFactor", "WageIndex", "IPPSBaseRate"}
-        
+        supporting_datasets = {
+            "GPCI",
+            "CF",
+            "ConversionFactor",
+            "WageIndex",
+            "IPPSBaseRate",
+        }
+
         # Build expanded dataset set if including supporting datasets
         datasets_to_extract = set(datasets_seen)
         if include_supporting_datasets:
             datasets_to_extract.update(supporting_datasets)
-        
+
         for item in line_items:
             if not item.trace_refs:
                 continue
-            
+
             # Extract provenance for all datasets found in trace_refs (primary and supporting)
             for ref in item.trace_refs:
-                if not ref or ':' not in ref:
+                if not ref or ":" not in ref:
                     continue
-                
-                parts = ref.split(':')
+
+                parts = ref.split(":")
                 if len(parts) == 3:
                     dataset, provenance_type, value = parts
-                    
+
                     # Only extract if dataset is in our target set
                     if dataset not in datasets_to_extract:
                         continue
-                    
+
                     # Initialize if needed (allow both release_id and batch_id to be extracted)
                     if dataset not in release_map:
                         release_map[dataset] = {"release_id": None, "batch_id": None}
-                    
+
                     # Extract provenance value (accumulate both release and batch)
-                    if provenance_type == 'release':
+                    if provenance_type == "release":
                         release_map[dataset]["release_id"] = value
-                    elif provenance_type == 'batch':
+                    elif provenance_type == "batch":
                         release_map[dataset]["batch_id"] = value
-        
+
         # Remove entries with no provenance (cleanup)
-        return {k: v for k, v in release_map.items() if v["release_id"] or v["batch_id"]}
+        return {
+            k: v for k, v in release_map.items() if v["release_id"] or v["batch_id"]
+        }

--- a/tests/services/test_mpfs_component_pricing.py
+++ b/tests/services/test_mpfs_component_pricing.py
@@ -1,9 +1,27 @@
 from unittest.mock import MagicMock
+from datetime import date
+from decimal import Decimal
+import uuid
 
 import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import OperationalError, ProgrammingError
 
 from cms_pricing.engines.mpfs import MPSFEngine
+from cms_pricing.models.dataset_snapshots import DatasetSnapshot
+from cms_pricing.models.rvu import GPCIIndex, Release, RVUItem
 from cms_pricing.schemas.geography import GeographyCandidate, GeographyResolveResponse
+
+
+def _require_table(db_session, table_name: str) -> None:
+    try:
+        db_session.execute(text(f"SELECT 1 FROM {table_name} LIMIT 1"))
+    except (ProgrammingError, OperationalError) as exc:
+        if "does not exist" in str(exc) or "relation" in str(exc).lower():
+            pytest.skip(
+                f"Table {table_name} is not available. Run alembic migrations before this test."
+            )
+        raise
 
 
 def _row(**values):
@@ -108,7 +126,10 @@ async def test_mpfs_prices_professional_technical_and_global_components(
     assert result.professional_allowed_cents == expected_professional
     assert result.facility_allowed_cents == expected_technical
     assert result.beneficiary_coinsurance_cents == round(expected_allowed * 0.20)
-    assert result.program_payment_cents == expected_allowed - result.beneficiary_total_cents
+    assert (
+        result.program_payment_cents
+        == expected_allowed - result.beneficiary_total_cents
+    )
 
 
 @pytest.mark.unit
@@ -178,3 +199,164 @@ async def test_mpfs_component_modifier_overrides_component_flags():
     assert result.allowed_cents == 2000
     assert result.professional_allowed_cents == 0
     assert result.facility_allowed_cents == 2000
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_mpfs_uses_rvu_snapshots_by_valuation_date(test_db_session):
+    for table_name in ("dataset_snapshots", "releases", "rvu_items", "gpci_indices"):
+        _require_table(test_db_session, table_name)
+
+    release_b_id = uuid.uuid4()
+    release_c_id = uuid.uuid4()
+    snapshot_release_ids = ["rvu_2029_B", "gpci_2029_B", "rvu_2029_C", "gpci_2029_C"]
+    release_source_versions = ["rvu_2029_B", "rvu_2029_C"]
+    existing_release_ids = [
+        row[0]
+        for row in test_db_session.query(Release.id)
+        .filter(Release.source_version.in_(release_source_versions))
+        .all()
+    ]
+    release_ids_to_delete = existing_release_ids + [release_b_id, release_c_id]
+
+    test_db_session.query(DatasetSnapshot).filter(
+        DatasetSnapshot.release_id.in_(snapshot_release_ids)
+    ).delete(synchronize_session=False)
+    test_db_session.query(RVUItem).filter(
+        RVUItem.release_id.in_(release_ids_to_delete)
+    ).delete(synchronize_session=False)
+    test_db_session.query(GPCIIndex).filter(
+        GPCIIndex.release_id.in_(release_ids_to_delete)
+    ).delete(synchronize_session=False)
+    test_db_session.query(Release).filter(Release.id.in_(release_ids_to_delete)).delete(
+        synchronize_session=False
+    )
+    test_db_session.commit()
+
+    releases = [
+        Release(
+            id=release_b_id,
+            type="RVU_FULL",
+            source_version="rvu_2029_B",
+            imported_at=date(2029, 4, 1),
+            notes="batch-b",
+        ),
+        Release(
+            id=release_c_id,
+            type="RVU_FULL",
+            source_version="rvu_2029_C",
+            imported_at=date(2029, 7, 1),
+            notes="batch-c",
+        ),
+    ]
+    snapshots = [
+        DatasetSnapshot(
+            dataset_id="rvu_items",
+            release_id="rvu_2029_B",
+            digest="sha256:rvu-b",
+            effective_from=date(2029, 4, 1),
+        ),
+        DatasetSnapshot(
+            dataset_id="gpci_indices",
+            release_id="gpci_2029_B",
+            digest="sha256:gpci-b",
+            effective_from=date(2029, 4, 1),
+        ),
+        DatasetSnapshot(
+            dataset_id="rvu_items",
+            release_id="rvu_2029_C",
+            digest="sha256:rvu-c",
+            effective_from=date(2029, 7, 1),
+        ),
+        DatasetSnapshot(
+            dataset_id="gpci_indices",
+            release_id="gpci_2029_C",
+            digest="sha256:gpci-c",
+            effective_from=date(2029, 7, 1),
+        ),
+    ]
+    rvu_rows = [
+        RVUItem(
+            id=uuid.uuid4(),
+            release_id=release_b_id,
+            hcpcs_code="99213",
+            modifier_key="",
+            work_rvu=Decimal("1.0000"),
+            pe_rvu_nonfac=Decimal("2.0000"),
+            pe_rvu_fac=Decimal("3.0000"),
+            mp_rvu=Decimal("0.5000"),
+            conversion_factor=Decimal("10.0000"),
+            effective_start=date(2029, 4, 1),
+        ),
+        RVUItem(
+            id=uuid.uuid4(),
+            release_id=release_c_id,
+            hcpcs_code="99213",
+            modifier_key="",
+            work_rvu=Decimal("2.0000"),
+            pe_rvu_nonfac=Decimal("4.0000"),
+            pe_rvu_fac=Decimal("6.0000"),
+            mp_rvu=Decimal("1.0000"),
+            conversion_factor=Decimal("10.0000"),
+            effective_start=date(2029, 7, 1),
+        ),
+    ]
+    gpci_rows = [
+        GPCIIndex(
+            id=uuid.uuid4(),
+            release_id=release_b_id,
+            mac="TSTMAC",
+            state="CA",
+            locality_id="05",
+            locality_name="Test California",
+            work_gpci=Decimal("1.0000"),
+            pe_gpci=Decimal("1.0000"),
+            mp_gpci=Decimal("1.0000"),
+            effective_start=date(2029, 4, 1),
+        ),
+        GPCIIndex(
+            id=uuid.uuid4(),
+            release_id=release_c_id,
+            mac="TSTMAC",
+            state="CA",
+            locality_id="05",
+            locality_name="Test California",
+            work_gpci=Decimal("1.0000"),
+            pe_gpci=Decimal("1.0000"),
+            mp_gpci=Decimal("1.0000"),
+            effective_start=date(2029, 7, 1),
+        ),
+    ]
+
+    test_db_session.add_all(releases + snapshots + rvu_rows + gpci_rows)
+    test_db_session.commit()
+
+    engine = MPSFEngine(db=test_db_session)
+
+    before_effective = await engine.price_code(
+        code="99213",
+        zip="94110",
+        year=2029,
+        geography=_geography("05"),
+        pos="11",
+        valuation_date=date(2029, 6, 30),
+    )
+    after_effective = await engine.price_code(
+        code="99213",
+        zip="94110",
+        year=2029,
+        geography=_geography("05"),
+        pos="11",
+        valuation_date=date(2029, 7, 1),
+    )
+
+    assert before_effective.release_id == "rvu_2029_B"
+    assert before_effective.allowed_cents == 3500
+    assert "RVU:release:rvu_2029_B" in before_effective.trace_refs
+    assert "GPCI:release:gpci_2029_B" in before_effective.trace_refs
+    assert "CF:source:rvu_items.conversion_factor" in before_effective.trace_refs
+
+    assert after_effective.release_id == "rvu_2029_C"
+    assert after_effective.allowed_cents == 7000
+    assert "RVU:release:rvu_2029_C" in after_effective.trace_refs
+    assert "GPCI:release:gpci_2029_C" in after_effective.trace_refs


### PR DESCRIPTION
## Summary

Wires loaded RVU/GPCI snapshot data into MPFS pricing so valuation-date pricing can use the live RVU tables before falling back to legacy benchmark rows.

- Adds MPFS pricing selection from `dataset_snapshots`, `releases`, `rvu_items`, and `gpci_indices`.
- Uses valuation date / quarter to select the active RVU and GPCI snapshots.
- Preserves legacy MPFS benchmark fallback when RVU snapshots are unavailable.
- Carries release, GPCI, and conversion-factor provenance through trace refs.
- Threads `valuation_date` through pricing router/service request handling for MPFS.
- Adds component pricing coverage for selecting different RVU releases across effective dates.

## Validation

Passed:

- `git diff --check -- cms_pricing/engines/mpfs.py cms_pricing/routers/pricing.py cms_pricing/schemas/pricing.py cms_pricing/services/pricing.py tests/services/test_mpfs_component_pricing.py`
- `.venv/bin/python -m pytest tests/services/test_pricing_provenance.py -q` -> 9 passed
- `.venv/bin/python -m pytest tests/services/test_mpfs_component_pricing.py -q` outside sandbox -> 11 passed

Known failure outside this PR scope:

- `.venv/bin/python -m pytest tests/services/test_dataset_snapshot_service.py -q` outside sandbox -> 12 passed, 1 failed
- Failing test: `test_resolve_curated_path_falls_back_to_latest_drop`
- Failure is a pre-existing/unrelated curated-path fallback assertion: expected `2025-11-06` latest-drop path, actual remained the manifest `2025-11-10` path.

Sandbox note:

- DB-backed tests initially failed in the managed sandbox with localhost Postgres `Operation not permitted`; rerunning outside the sandbox allowed DB access.

## PR Structure

This is a stacked PR against `codex/rvu-pricing-tracker-tasks` so the review only shows the RVU pricing code edits. The base branch is draft PR #444.