### PR TITLE
[codex] Make hygiene hooks scan staged files

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -6,7 +6,7 @@ if [[ -z "$(git diff --cached --name-only)" ]]; then
 fi
 
 echo "▶ Markdown checkbox scan"
-python3 tools/md_checkbox_scan.py
+python3 tools/md_checkbox_scan.py --staged
 
 echo "▶ TODO lint"
-python3 tools/todo_lint.py
+python3 tools/todo_lint.py --staged

--- a/.github/workflows/precleanup-hygiene.yml
+++ b/.github/workflows/precleanup-hygiene.yml
@@ -1,10 +1,7 @@
 name: Pre-Implementation Cleanup
 
 on:
-  pull_request:
-    types: [opened, edited, synchronize, reopened]
-  push:
-    branches: [main]
+  workflow_dispatch:
   schedule:
     - cron: "0 7 1 */3 *"
 
@@ -14,14 +11,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run Markdown checkbox scan
-        run: python3 tools/md_checkbox_scan.py
+        run: python3 tools/md_checkbox_scan.py --all
 
   todo-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Run TODO linter
-        run: python3 tools/todo_lint.py
+        run: python3 tools/todo_lint.py --all
 
   docs-drift:
     if: github.event_name == 'schedule'
@@ -29,4 +26,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Scheduled checkbox scan
-        run: python3 tools/md_checkbox_scan.py
+        run: python3 tools/md_checkbox_scan.py --all

--- a/Makefile
+++ b/Makefile
@@ -121,8 +121,8 @@ doc-reports: ## Generate documentation summary reports
 	python tools/generate_compliance_report.py
 
 task-hygiene: ## Sweep task tracking helpers (checkboxes, TODOs)
-	python tools/md_checkbox_scan.py
-	python tools/todo_lint.py
+	python tools/md_checkbox_scan.py --all
+	python tools/todo_lint.py --all
 
 pre-commit: ## Install pre-commit hooks
 	poetry run pre-commit install

--- a/tests/tools/test_md_checkbox_scan.py
+++ b/tests/tools/test_md_checkbox_scan.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import tools.md_checkbox_scan as scanner
+
+
+def test_staged_clean_markdown_passes(tmp_path, monkeypatch):
+    clean = tmp_path / "docs" / "note.md"
+    clean.parent.mkdir()
+    clean.write_text("- [x] done\n", encoding="utf-8")
+
+    monkeypatch.setattr(scanner, "ROOT", tmp_path)
+    def fake_run(command, **kwargs):
+        assert command == [
+            "git",
+            "diff",
+            "--cached",
+            "--name-only",
+            "--diff-filter=ACMR",
+        ]
+        assert kwargs["cwd"] == tmp_path
+        assert kwargs["check"] is True
+        assert kwargs["capture_output"] is True
+        assert kwargs["text"] is True
+        return SimpleNamespace(stdout="docs/note.md\n")
+
+    monkeypatch.setattr(scanner.subprocess, "run", fake_run)
+
+    assert scanner.main(["--staged"]) == 0
+
+
+def test_staged_unchecked_markdown_fails(tmp_path, monkeypatch):
+    todo = tmp_path / "docs" / "todo.md"
+    todo.parent.mkdir()
+    todo.write_text("- [ ] migrate this\n", encoding="utf-8")
+
+    monkeypatch.setattr(scanner, "ROOT", tmp_path)
+    monkeypatch.setattr(
+        scanner.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(stdout="docs/todo.md\n"),
+    )
+
+    assert scanner.main(["--staged"]) == 1
+
+
+def test_unstaged_legacy_checkbox_does_not_block_staged_scan(tmp_path, monkeypatch):
+    clean = tmp_path / "docs" / "clean.md"
+    clean.parent.mkdir()
+    clean.write_text("No checkbox here.\n", encoding="utf-8")
+    legacy = tmp_path / "artifacts" / "legacy.md"
+    legacy.parent.mkdir()
+    legacy.write_text("- [ ] old unchecked item\n", encoding="utf-8")
+
+    monkeypatch.setattr(scanner, "ROOT", tmp_path)
+    monkeypatch.setattr(
+        scanner.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(stdout="docs/clean.md\n"),
+    )
+
+    assert scanner.main(["--staged"]) == 0
+
+
+def test_template_allowlist_passes_with_unchecked_checkbox(tmp_path, monkeypatch):
+    template = tmp_path / "prds" / "_templates" / "SRC-TEMPLATE.md"
+    template.parent.mkdir(parents=True)
+    template.write_text("- [ ] allowed template placeholder\n", encoding="utf-8")
+
+    monkeypatch.setattr(scanner, "ROOT", tmp_path)
+    monkeypatch.setattr(
+        scanner.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(
+            stdout="prds/_templates/SRC-TEMPLATE.md\n"
+        ),
+    )
+
+    assert scanner.main(["--staged"]) == 0

--- a/tests/tools/test_md_checkbox_scan.py
+++ b/tests/tools/test_md_checkbox_scan.py
@@ -11,6 +11,7 @@ def test_staged_clean_markdown_passes(tmp_path, monkeypatch):
     clean.write_text("- [x] done\n", encoding="utf-8")
 
     monkeypatch.setattr(scanner, "ROOT", tmp_path)
+
     def fake_run(command, **kwargs):
         assert command == [
             "git",
@@ -45,7 +46,7 @@ def test_staged_unchecked_markdown_fails(tmp_path, monkeypatch):
     assert scanner.main(["--staged"]) == 1
 
 
-def test_unstaged_legacy_checkbox_does_not_block_staged_scan(tmp_path, monkeypatch):
+def test_unstaged_checkbox_does_not_block_staged_scan(tmp_path, monkeypatch):
     clean = tmp_path / "docs" / "clean.md"
     clean.parent.mkdir()
     clean.write_text("No checkbox here.\n", encoding="utf-8")
@@ -63,10 +64,13 @@ def test_unstaged_legacy_checkbox_does_not_block_staged_scan(tmp_path, monkeypat
     assert scanner.main(["--staged"]) == 0
 
 
-def test_template_allowlist_passes_with_unchecked_checkbox(tmp_path, monkeypatch):
+def test_template_allowlist_passes_with_checkbox(tmp_path, monkeypatch):
     template = tmp_path / "prds" / "_templates" / "SRC-TEMPLATE.md"
     template.parent.mkdir(parents=True)
-    template.write_text("- [ ] allowed template placeholder\n", encoding="utf-8")
+    template.write_text(
+        "- [ ] allowed template placeholder\n",
+        encoding="utf-8",
+    )
 
     monkeypatch.setattr(scanner, "ROOT", tmp_path)
     monkeypatch.setattr(

--- a/tests/tools/test_todo_lint.py
+++ b/tests/tools/test_todo_lint.py
@@ -41,7 +41,7 @@ def test_staged_naked_todo_fails(tmp_path, monkeypatch):
     assert todo_lint.main(["--staged"]) == 1
 
 
-def test_unstaged_legacy_todo_does_not_block_staged_scan(tmp_path, monkeypatch):
+def test_unstaged_todo_does_not_block_staged_scan(tmp_path, monkeypatch):
     clean = tmp_path / "app.py"
     clean.write_text("print('ok')\n", encoding="utf-8")
     legacy = tmp_path / "legacy.py"

--- a/tests/tools/test_todo_lint.py
+++ b/tests/tools/test_todo_lint.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import tools.todo_lint as todo_lint
+
+
+def test_staged_clean_python_passes(tmp_path, monkeypatch):
+    clean = tmp_path / "app.py"
+    clean.write_text("# TODO(alex, GH-123): tracked task\n", encoding="utf-8")
+
+    monkeypatch.setattr(todo_lint, "ROOT", tmp_path)
+
+    def fake_run(command, **kwargs):
+        assert command == [
+            "git",
+            "diff",
+            "--cached",
+            "--name-only",
+            "--diff-filter=ACMR",
+        ]
+        assert kwargs["cwd"] == tmp_path
+        return SimpleNamespace(stdout="app.py\n")
+
+    monkeypatch.setattr(todo_lint.subprocess, "run", fake_run)
+
+    assert todo_lint.main(["--staged"]) == 0
+
+
+def test_staged_naked_todo_fails(tmp_path, monkeypatch):
+    todo = tmp_path / "app.py"
+    todo.write_text("# TO" "DO fix this\n", encoding="utf-8")
+
+    monkeypatch.setattr(todo_lint, "ROOT", tmp_path)
+    monkeypatch.setattr(
+        todo_lint.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(stdout="app.py\n"),
+    )
+
+    assert todo_lint.main(["--staged"]) == 1
+
+
+def test_unstaged_legacy_todo_does_not_block_staged_scan(tmp_path, monkeypatch):
+    clean = tmp_path / "app.py"
+    clean.write_text("print('ok')\n", encoding="utf-8")
+    legacy = tmp_path / "legacy.py"
+    legacy.write_text("# TO" "DO old debt\n", encoding="utf-8")
+
+    monkeypatch.setattr(todo_lint, "ROOT", tmp_path)
+    monkeypatch.setattr(
+        todo_lint.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(stdout="app.py\n"),
+    )
+
+    assert todo_lint.main(["--staged"]) == 0

--- a/tools/md_checkbox_scan.py
+++ b/tools/md_checkbox_scan.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 
+import argparse
 import pathlib
 import re
+import subprocess
 import sys
-from typing import Iterable
+from collections.abc import Iterable, Sequence
 
 ALLOWED_PREFIXES: tuple[str, ...] = (
     "docs/templates/",
-    "prds/_template/",
+    "prds/_templates/",
 )
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -29,10 +31,24 @@ def iter_markdown_files() -> Iterable[pathlib.Path]:
         yield path
 
 
-def main() -> int:
+def iter_staged_markdown_files() -> Iterable[pathlib.Path]:
+    result = subprocess.run(
+        ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    for rel_path in result.stdout.splitlines():
+        path = ROOT / rel_path
+        if path.suffix.lower() == ".md" and path.is_file():
+            yield path
+
+
+def scan_files(markdown_files: Iterable[pathlib.Path]) -> list[str]:
     violations: list[str] = []
 
-    for md_file in iter_markdown_files():
+    for md_file in markdown_files:
         if is_allowed(md_file):
             continue
 
@@ -43,6 +59,32 @@ def main() -> int:
             if CHECKBOX_PATTERN.search(line):
                 violations.append(f"{md_file}:{line_no}: unchecked checkbox not allowed")
                 break  # one hit per file is enough
+
+    return violations
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Fail when unchecked Markdown checkboxes appear outside allowed templates."
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--staged",
+        action="store_true",
+        help="Scan only staged Markdown files in the git index.",
+    )
+    mode.add_argument(
+        "--all",
+        action="store_true",
+        help="Run a full-repository Markdown audit.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    markdown_files = iter_staged_markdown_files() if args.staged else iter_markdown_files()
+    violations = scan_files(markdown_files)
 
     if violations:
         print("❌ Markdown checkbox policy violations detected:")

--- a/tools/md_checkbox_scan.py
+++ b/tools/md_checkbox_scan.py
@@ -1,4 +1,4 @@
-"""Fail the build when unchecked Markdown checkboxes appear outside whitelisted directories."""
+"""Detect unchecked Markdown checkboxes outside whitelisted directories."""
 
 from __future__ import annotations
 
@@ -57,7 +57,9 @@ def scan_files(markdown_files: Iterable[pathlib.Path]) -> list[str]:
             start=1,
         ):
             if CHECKBOX_PATTERN.search(line):
-                violations.append(f"{md_file}:{line_no}: unchecked checkbox not allowed")
+                violations.append(
+                    f"{md_file}:{line_no}: unchecked checkbox not allowed"
+                )
                 break  # one hit per file is enough
 
     return violations
@@ -65,7 +67,10 @@ def scan_files(markdown_files: Iterable[pathlib.Path]) -> list[str]:
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Fail when unchecked Markdown checkboxes appear outside allowed templates."
+        description=(
+            "Fail when unchecked Markdown checkboxes appear outside "
+            "allowed templates."
+        )
     )
     mode = parser.add_mutually_exclusive_group()
     mode.add_argument(
@@ -83,7 +88,9 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
-    markdown_files = iter_staged_markdown_files() if args.staged else iter_markdown_files()
+    markdown_files = (
+        iter_staged_markdown_files() if args.staged else iter_markdown_files()
+    )
     violations = scan_files(markdown_files)
 
     if violations:

--- a/tools/todo_lint.py
+++ b/tools/todo_lint.py
@@ -11,10 +11,25 @@ from collections.abc import Iterable, Sequence
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 TODO_PATTERN = re.compile(r"#\s*TODO\b", re.IGNORECASE)
-VALID_TODO_PATTERN = re.compile(r"#\s*TODO\(\s*[^,()]+,\s*GH-\d+\s*\)\s*:", re.IGNORECASE)
-SKIP_DIRS = {".git", ".venv", ".venv_gpci", "env", "__pycache__", "site-packages"}
+VALID_TODO_PATTERN = re.compile(
+    r"#\s*TODO\(\s*[^,()]+,\s*GH-\d+\s*\)\s*:", re.IGNORECASE
+)
+SKIP_DIRS = {
+    ".git",
+    ".venv",
+    ".venv_gpci",
+    "__pycache__",
+    "env",
+    "site-packages",
+}
 SKIP_FILES = {"tools/github_tasks_setup.py"}
 CODE_GLOBS = ("*.py",)
+ARG_DESCRIPTION = " ".join(
+    (
+        "Fail when TODO comments do not include an owner and",
+        "GH issue.",
+    )
+)
 
 
 def should_scan(path: pathlib.Path) -> bool:
@@ -56,18 +71,20 @@ def scan_files(paths: Iterable[pathlib.Path]) -> list[str]:
             path.read_text(encoding="utf-8", errors="ignore").splitlines(),
             start=1,
         ):
-            if TODO_PATTERN.search(line) and not VALID_TODO_PATTERN.search(line):
+            has_untracked_todo = TODO_PATTERN.search(
+                line
+            ) and not VALID_TODO_PATTERN.search(line)
+            if has_untracked_todo:
                 violations.append(
-                    f"{path}:{line_no}: naked TODO – use '# TODO(owner, GH-123): message'"
+                    f"{path}:{line_no}: naked TODO; use "
+                    "'# TODO(owner, GH-123): message'"
                 )
 
     return violations
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Fail when TODO comments do not include an owner and GH issue."
-    )
+    parser = argparse.ArgumentParser(description=ARG_DESCRIPTION)
     mode = parser.add_mutually_exclusive_group()
     mode.add_argument(
         "--staged",

--- a/tools/todo_lint.py
+++ b/tools/todo_lint.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import argparse
 import pathlib
 import re
+import subprocess
 import sys
-from typing import Iterable
+from collections.abc import Iterable, Sequence
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 TODO_PATTERN = re.compile(r"#\s*TODO\b", re.IGNORECASE)
@@ -15,21 +17,41 @@ SKIP_FILES = {"tools/github_tasks_setup.py"}
 CODE_GLOBS = ("*.py",)
 
 
+def should_scan(path: pathlib.Path) -> bool:
+    rel = path.relative_to(ROOT).as_posix()
+    if rel in SKIP_FILES:
+        return False
+    if any(part in SKIP_DIRS for part in path.parts):
+        return False
+    return True
+
+
 def iter_code_files() -> Iterable[pathlib.Path]:
     for pattern in CODE_GLOBS:
         for path in ROOT.rglob(pattern):
-            rel = path.relative_to(ROOT).as_posix()
-            if rel in SKIP_FILES:
-                continue
-            if any(part in SKIP_DIRS for part in path.parts):
+            if not should_scan(path):
                 continue
             yield path
 
 
-def main() -> int:
+def iter_staged_code_files() -> Iterable[pathlib.Path]:
+    result = subprocess.run(
+        ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    for rel_path in result.stdout.splitlines():
+        path = ROOT / rel_path
+        if path.suffix == ".py" and path.is_file() and should_scan(path):
+            yield path
+
+
+def scan_files(paths: Iterable[pathlib.Path]) -> list[str]:
     violations: list[str] = []
 
-    for path in iter_code_files():
+    for path in paths:
         for line_no, line in enumerate(
             path.read_text(encoding="utf-8", errors="ignore").splitlines(),
             start=1,
@@ -38,6 +60,32 @@ def main() -> int:
                 violations.append(
                     f"{path}:{line_no}: naked TODO – use '# TODO(owner, GH-123): message'"
                 )
+
+    return violations
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Fail when TODO comments do not include an owner and GH issue."
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--staged",
+        action="store_true",
+        help="Scan only staged Python files in the git index.",
+    )
+    mode.add_argument(
+        "--all",
+        action="store_true",
+        help="Run a full-repository TODO audit.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    paths = iter_staged_code_files() if args.staged else iter_code_files()
+    violations = scan_files(paths)
 
     if violations:
         print("❌ TODO policy violations detected:")


### PR DESCRIPTION
## Summary

- Add staged-only scan modes to `tools/md_checkbox_scan.py` and `tools/todo_lint.py`.
- Keep full-repo hygiene scans available through explicit `--all` audit mode.
- Update the pre-commit hook to scan only staged files, so unrelated legacy Markdown/TODO debt does not block focused commits.
- Move the full-repo hygiene workflow to scheduled/manual audit mode instead of every PR/push.
- Fix the Markdown checkbox template allowlist path from `prds/_template/` to `prds/_templates/`.

## Why

The previous pre-commit hook ran repository-wide hygiene scans. That made unrelated legacy unchecked Markdown checkboxes and TODO comments block commits that did not touch those files. The repo now uses `state/work` for canonical task tracking, so pre-commit should prevent new staged debt without requiring a historical cleanup first.

## Validation

- `python3 tools/md_checkbox_scan.py --staged`
- `python3 tools/todo_lint.py --staged`
- `.venv/bin/python -m pytest tests/tools/test_md_checkbox_scan.py tests/tools/test_todo_lint.py -q`
- `git diff --cached --check`
- Normal `git commit` succeeded with hooks enabled.