### PR TITLE
[codex] Make hygiene PR checks diff-scoped

### DIFF
--- a/.github/workflows/precleanup-hygiene.yml
+++ b/.github/workflows/precleanup-hygiene.yml
@@ -1,6 +1,8 @@
 name: Pre-Implementation Cleanup
 
 on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
   workflow_dispatch:
   schedule:
     - cron: "0 7 1 */3 *"
@@ -10,15 +12,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Run Markdown checkbox scan
-        run: python3 tools/md_checkbox_scan.py --all
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch origin "${{ github.base_ref }}" --depth=1
+            python3 tools/md_checkbox_scan.py --changed-from "origin/${{ github.base_ref }}"
+          else
+            python3 tools/md_checkbox_scan.py --all
+          fi
 
   todo-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Run TODO linter
-        run: python3 tools/todo_lint.py --all
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch origin "${{ github.base_ref }}" --depth=1
+            python3 tools/todo_lint.py --changed-from "origin/${{ github.base_ref }}"
+          else
+            python3 tools/todo_lint.py --all
+          fi
 
   docs-drift:
     if: github.event_name == 'schedule'

--- a/tests/tools/test_md_checkbox_scan.py
+++ b/tests/tools/test_md_checkbox_scan.py
@@ -46,6 +46,34 @@ def test_staged_unchecked_markdown_fails(tmp_path, monkeypatch):
     assert scanner.main(["--staged"]) == 1
 
 
+def test_changed_from_scans_only_changed_markdown(tmp_path, monkeypatch):
+    clean = tmp_path / "docs" / "clean.md"
+    clean.parent.mkdir()
+    clean.write_text("No checkbox here.\n", encoding="utf-8")
+    legacy = tmp_path / "docs" / "legacy.md"
+    legacy.write_text("- [ ] old unchecked item\n", encoding="utf-8")
+
+    monkeypatch.setattr(scanner, "ROOT", tmp_path)
+
+    def fake_run(command, **kwargs):
+        assert command == [
+            "git",
+            "diff",
+            "--name-only",
+            "--diff-filter=ACMR",
+            "origin/main...HEAD",
+        ]
+        assert kwargs["cwd"] == tmp_path
+        assert kwargs["check"] is True
+        assert kwargs["capture_output"] is True
+        assert kwargs["text"] is True
+        return SimpleNamespace(stdout="docs/clean.md\n")
+
+    monkeypatch.setattr(scanner.subprocess, "run", fake_run)
+
+    assert scanner.main(["--changed-from", "origin/main"]) == 0
+
+
 def test_unstaged_checkbox_does_not_block_staged_scan(tmp_path, monkeypatch):
     clean = tmp_path / "docs" / "clean.md"
     clean.parent.mkdir()

--- a/tests/tools/test_todo_lint.py
+++ b/tests/tools/test_todo_lint.py
@@ -41,6 +41,33 @@ def test_staged_naked_todo_fails(tmp_path, monkeypatch):
     assert todo_lint.main(["--staged"]) == 1
 
 
+def test_changed_from_scans_only_changed_python(tmp_path, monkeypatch):
+    clean = tmp_path / "app.py"
+    clean.write_text("print('ok')\n", encoding="utf-8")
+    legacy = tmp_path / "legacy.py"
+    legacy.write_text("# TO" "DO old debt\n", encoding="utf-8")
+
+    monkeypatch.setattr(todo_lint, "ROOT", tmp_path)
+
+    def fake_run(command, **kwargs):
+        assert command == [
+            "git",
+            "diff",
+            "--name-only",
+            "--diff-filter=ACMR",
+            "origin/main...HEAD",
+        ]
+        assert kwargs["cwd"] == tmp_path
+        assert kwargs["check"] is True
+        assert kwargs["capture_output"] is True
+        assert kwargs["text"] is True
+        return SimpleNamespace(stdout="app.py\n")
+
+    monkeypatch.setattr(todo_lint.subprocess, "run", fake_run)
+
+    assert todo_lint.main(["--changed-from", "origin/main"]) == 0
+
+
 def test_unstaged_todo_does_not_block_staged_scan(tmp_path, monkeypatch):
     clean = tmp_path / "app.py"
     clean.write_text("print('ok')\n", encoding="utf-8")

--- a/tools/md_checkbox_scan.py
+++ b/tools/md_checkbox_scan.py
@@ -45,6 +45,26 @@ def iter_staged_markdown_files() -> Iterable[pathlib.Path]:
             yield path
 
 
+def iter_changed_markdown_files(base_ref: str) -> Iterable[pathlib.Path]:
+    result = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--name-only",
+            "--diff-filter=ACMR",
+            f"{base_ref}...HEAD",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    for rel_path in result.stdout.splitlines():
+        path = ROOT / rel_path
+        if path.suffix.lower() == ".md" and path.is_file():
+            yield path
+
+
 def scan_files(markdown_files: Iterable[pathlib.Path]) -> list[str]:
     violations: list[str] = []
 
@@ -83,14 +103,22 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Run a full-repository Markdown audit.",
     )
+    mode.add_argument(
+        "--changed-from",
+        metavar="BASE_REF",
+        help="Scan Markdown files changed from BASE_REF to HEAD.",
+    )
     return parser.parse_args(argv)
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
-    markdown_files = (
-        iter_staged_markdown_files() if args.staged else iter_markdown_files()
-    )
+    if args.staged:
+        markdown_files = iter_staged_markdown_files()
+    elif args.changed_from:
+        markdown_files = iter_changed_markdown_files(args.changed_from)
+    else:
+        markdown_files = iter_markdown_files()
     violations = scan_files(markdown_files)
 
     if violations:

--- a/tools/todo_lint.py
+++ b/tools/todo_lint.py
@@ -63,6 +63,26 @@ def iter_staged_code_files() -> Iterable[pathlib.Path]:
             yield path
 
 
+def iter_changed_code_files(base_ref: str) -> Iterable[pathlib.Path]:
+    result = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--name-only",
+            "--diff-filter=ACMR",
+            f"{base_ref}...HEAD",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    for rel_path in result.stdout.splitlines():
+        path = ROOT / rel_path
+        if path.suffix == ".py" and path.is_file() and should_scan(path):
+            yield path
+
+
 def scan_files(paths: Iterable[pathlib.Path]) -> list[str]:
     violations: list[str] = []
 
@@ -96,12 +116,22 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Run a full-repository TODO audit.",
     )
+    mode.add_argument(
+        "--changed-from",
+        metavar="BASE_REF",
+        help="Scan Python files changed from BASE_REF to HEAD.",
+    )
     return parser.parse_args(argv)
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
-    paths = iter_staged_code_files() if args.staged else iter_code_files()
+    if args.staged:
+        paths = iter_staged_code_files()
+    elif args.changed_from:
+        paths = iter_changed_code_files(args.changed_from)
+    else:
+        paths = iter_code_files()
     violations = scan_files(paths)
 
     if violations:


### PR DESCRIPTION
## Summary

- Add `--changed-from BASE_REF` modes to the Markdown checkbox and TODO scanners.
- Re-enable the `Pre-Implementation Cleanup` workflow on pull requests while keeping the existing `checkbox-police` and `todo-lint` job names.
- Make PR runs scan only files changed from the PR base; scheduled/manual runs still use full-repo `--all` audits.
- Add tests proving pre-existing unchecked checkboxes and naked TODOs outside the PR diff do not block changed-file scans.

## Why

Repo-wide hygiene checks were catching historical unchecked checkboxes and naked TODOs outside the active PR diff. That makes unrelated implementation PRs fail on legacy debt. This keeps PR checks focused on preventing new debt while preserving full-repo audits for scheduled/manual cleanup.

## Validation

- `.venv/bin/black --check tests/tools/test_md_checkbox_scan.py tests/tools/test_todo_lint.py tools/md_checkbox_scan.py tools/todo_lint.py`
- `.venv/bin/isort --check-only tests/tools/test_md_checkbox_scan.py tests/tools/test_todo_lint.py tools/md_checkbox_scan.py tools/todo_lint.py`
- `.venv/bin/flake8 tests/tools/test_md_checkbox_scan.py tests/tools/test_todo_lint.py tools/md_checkbox_scan.py tools/todo_lint.py`
- `.venv/bin/python -m py_compile tests/tools/test_md_checkbox_scan.py tests/tools/test_todo_lint.py tools/md_checkbox_scan.py tools/todo_lint.py`
- `.venv/bin/pytest tests/tools/test_md_checkbox_scan.py tests/tools/test_todo_lint.py -q`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/precleanup-hygiene.yml")'`
- `git diff --cached --check`
- Commit hook passed staged Markdown checkbox and TODO lint scans.